### PR TITLE
feat: PWA対応 (issue #8)

### DIFF
--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test"
+
+test.describe("PWA マニフェスト", () => {
+  test("/manifest.webmanifest が正しく返される", async ({ request }) => {
+    const response = await request.get("/manifest.webmanifest")
+    expect(response.status()).toBe(200)
+
+    const manifest = await response.json()
+    expect(manifest.display).toBe("standalone")
+    expect(manifest.theme_color).toBe("#ff00cc")
+    expect(manifest.background_color).toBe("#0d0014")
+    expect(Array.isArray(manifest.icons)).toBe(true)
+    expect(manifest.icons.length).toBeGreaterThan(0)
+
+    const pngIcons = manifest.icons.filter((i: { type: string }) => i.type === "image/png")
+    expect(pngIcons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test("/icon-192 が PNG を返す", async ({ request }) => {
+    const response = await request.get("/icon-192")
+    expect(response.status()).toBe(200)
+    expect(response.headers()["content-type"]).toContain("image/png")
+  })
+
+  test("/icon-512 が PNG を返す", async ({ request }) => {
+    const response = await request.get("/icon-512")
+    expect(response.status()).toBe(200)
+    expect(response.headers()["content-type"]).toContain("image/png")
+  })
+})

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,5 +17,5 @@ export default auth((req) => {
 })
 
 export const config = {
-  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico|manifest.webmanifest|icon-192|icon-512).*)"],
 }

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -8,11 +8,6 @@
   </defs>
   <rect width="192" height="192" fill="url(#dots)"/>
 
-  <!-- outer border -->
-  <rect x="6" y="6" width="180" height="180" fill="none" stroke="#ff00cc" stroke-width="4" opacity="0.85"/>
-  <!-- inner border (glow layer) -->
-  <rect x="11" y="11" width="170" height="170" fill="none" stroke="#ff00cc" stroke-width="1" opacity="0.3"/>
-
   <!-- checkmark glow -->
   <polyline
     points="36,100 70,136 156,48"

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <rect width="192" height="192" fill="#0d0014"/>
+
+  <defs>
+    <pattern id="dots" x="0" y="0" width="12" height="12" patternUnits="userSpaceOnUse">
+      <rect x="0" y="0" width="2" height="2" fill="#ff00cc" opacity="0.25"/>
+    </pattern>
+  </defs>
+  <rect width="192" height="192" fill="url(#dots)"/>
+
+  <!-- outer border -->
+  <rect x="6" y="6" width="180" height="180" fill="none" stroke="#ff00cc" stroke-width="4" opacity="0.85"/>
+  <!-- inner border (glow layer) -->
+  <rect x="11" y="11" width="170" height="170" fill="none" stroke="#ff00cc" stroke-width="1" opacity="0.3"/>
+
+  <!-- checkmark glow -->
+  <polyline
+    points="36,100 70,136 156,48"
+    fill="none"
+    stroke="#ff00cc"
+    stroke-width="26"
+    stroke-linecap="square"
+    stroke-linejoin="miter"
+    opacity="0.2"
+  />
+  <!-- checkmark -->
+  <polyline
+    points="36,100 70,136 156,48"
+    fill="none"
+    stroke="#ff00cc"
+    stroke-width="14"
+    stroke-linecap="square"
+    stroke-linejoin="miter"
+  />
+</svg>

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,47 +1,9 @@
 import { ImageResponse } from "next/og"
+import { cyberIconJsx } from "@/lib/cyber-icon-jsx"
 
 export const size = { width: 180, height: 180 }
 export const contentType = "image/png"
 
 export default function AppleIcon() {
-  return new ImageResponse(
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        background: "#0d0014",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        position: "relative",
-      }}
-    >
-      {/* border */}
-      <div
-        style={{
-          position: "absolute",
-          inset: 8,
-          border: "3px solid rgba(255,0,204,0.8)",
-          display: "flex",
-        }}
-      />
-      {/* checkmark */}
-      <svg
-        viewBox="0 0 100 100"
-        width={110}
-        height={110}
-        style={{ display: "flex" }}
-      >
-        <polyline
-          points="15,50 40,75 85,25"
-          fill="none"
-          stroke="#ff00cc"
-          strokeWidth="10"
-          strokeLinecap="square"
-          strokeLinejoin="miter"
-        />
-      </svg>
-    </div>,
-    { width: 180, height: 180 },
-  )
+  return new ImageResponse(cyberIconJsx(180), { width: 180, height: 180 })
 }

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,47 @@
+import { ImageResponse } from "next/og"
+
+export const size = { width: 180, height: 180 }
+export const contentType = "image/png"
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        background: "#0d0014",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        position: "relative",
+      }}
+    >
+      {/* border */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 8,
+          border: "3px solid rgba(255,0,204,0.8)",
+          display: "flex",
+        }}
+      />
+      {/* checkmark */}
+      <svg
+        viewBox="0 0 100 100"
+        width={110}
+        height={110}
+        style={{ display: "flex" }}
+      >
+        <polyline
+          points="15,50 40,75 85,25"
+          fill="none"
+          stroke="#ff00cc"
+          strokeWidth="10"
+          strokeLinecap="square"
+          strokeLinejoin="miter"
+        />
+      </svg>
+    </div>,
+    { width: 180, height: 180 },
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,7 +14,6 @@
 }
 
 body {
-  font-family: var(--font-dot-gothic), "Dot Gothic 16", monospace;
   color: var(--cyber-text);
   background-color: var(--cyber-bg);
 }

--- a/src/app/icon-192/route.ts
+++ b/src/app/icon-192/route.ts
@@ -1,0 +1,6 @@
+import { ImageResponse } from "next/og"
+import { cyberIconJsx } from "@/lib/cyber-icon-jsx"
+
+export function GET() {
+  return new ImageResponse(cyberIconJsx(192), { width: 192, height: 192 })
+}

--- a/src/app/icon-512/route.ts
+++ b/src/app/icon-512/route.ts
@@ -1,0 +1,6 @@
+import { ImageResponse } from "next/og"
+import { cyberIconJsx } from "@/lib/cyber-icon-jsx"
+
+export function GET() {
+  return new ImageResponse(cyberIconJsx(512), { width: 512, height: 512 })
+}

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,24 +1,9 @@
 import { ImageResponse } from "next/og"
+import { cyberIconJsx } from "@/lib/cyber-icon-jsx"
 
 export const size = { width: 32, height: 32 }
 export const contentType = "image/png"
 
 export default function Icon() {
-  return new ImageResponse(
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        background: "#0d0014",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        border: "2px solid #ff00cc",
-        boxSizing: "border-box",
-      }}
-    >
-      <span style={{ color: "#ff00cc", fontSize: 20, lineHeight: 1, display: "flex" }}>✓</span>
-    </div>,
-    { width: 32, height: 32 },
-  )
+  return new ImageResponse(cyberIconJsx(32), { width: 32, height: 32 })
 }

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,24 @@
+import { ImageResponse } from "next/og"
+
+export const size = { width: 32, height: 32 }
+export const contentType = "image/png"
+
+export default function Icon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        background: "#0d0014",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: "2px solid #ff00cc",
+        boxSizing: "border-box",
+      }}
+    >
+      <span style={{ color: "#ff00cc", fontSize: 20, lineHeight: 1, display: "flex" }}>✓</span>
+    </div>,
+    { width: 32, height: 32 },
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css"
 
 const dotGothic = DotGothic16({
   weight: "400",
-  subsets: ["latin"],
+  subsets: ["latin", "japanese"],
   display: "swap",
   preload: false,
   variable: "--font-dot-gothic",
@@ -21,12 +21,13 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   colorScheme: "dark",
+  themeColor: "#ff00cc",
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja" className={`h-full ${dotGothic.variable}`} suppressHydrationWarning>
-      <body className="h-full bg-[#0d0014] antialiased">{children}</body>
+      <body className={`h-full bg-[#0d0014] antialiased ${dotGothic.className}`}>{children}</body>
     </html>
   )
 }

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -16,14 +16,14 @@ export default function manifest(): MetadataRoute.Manifest {
         type: "image/svg+xml",
       },
       {
-        src: "/icon.svg",
+        src: "/icon-192",
         sizes: "192x192",
-        type: "image/svg+xml",
+        type: "image/png",
       },
       {
-        src: "/icon.svg",
+        src: "/icon-512",
         sizes: "512x512",
-        type: "image/svg+xml",
+        type: "image/png",
         purpose: "maskable",
       },
     ],

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from "next"
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "To-do",
+    short_name: "To-do",
+    description: "Notion タスク管理",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0d0014",
+    theme_color: "#ff00cc",
+    icons: [
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+      },
+      {
+        src: "/icon.svg",
+        sizes: "192x192",
+        type: "image/svg+xml",
+      },
+      {
+        src: "/icon.svg",
+        sizes: "512x512",
+        type: "image/svg+xml",
+        purpose: "maskable",
+      },
+    ],
+  }
+}

--- a/src/lib/cyber-icon-jsx.tsx
+++ b/src/lib/cyber-icon-jsx.tsx
@@ -1,0 +1,52 @@
+export function cyberIconJsx(size: number) {
+  const isSmall = size <= 48
+  const dotSpacing = isSmall ? 4 : 12
+  const dotRadius = isSmall ? 0.5 : 1
+  const borderWidth = isSmall ? 2 : Math.max(4, Math.floor(size / 64))
+  const checkSize = Math.floor(size * 0.58)
+  const strokeWidth = isSmall ? 2 : 2.5
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        background: "#0d0014",
+        backgroundImage: `radial-gradient(circle, rgba(255,0,204,0.25) ${dotRadius}px, transparent ${dotRadius}px)`,
+        backgroundSize: `${dotSpacing}px ${dotSpacing}px`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: `${borderWidth}px solid rgba(255,0,204,0.8)`,
+        boxSizing: "border-box",
+      }}
+    >
+      <svg
+        width={checkSize}
+        height={checkSize}
+        viewBox="0 0 20 20"
+        style={{ display: "flex" }}
+      >
+        {!isSmall && (
+          <polyline
+            points="3,10 8,15 17,5"
+            fill="none"
+            stroke="#ff00cc"
+            strokeWidth={strokeWidth * 3}
+            strokeLinecap="square"
+            strokeLinejoin="miter"
+            opacity={0.2}
+          />
+        )}
+        <polyline
+          points="3,10 8,15 17,5"
+          fill="none"
+          stroke="#ff00cc"
+          strokeWidth={strokeWidth}
+          strokeLinecap="square"
+          strokeLinejoin="miter"
+        />
+      </svg>
+    </div>
+  )
+}

--- a/src/lib/cyber-icon-jsx.tsx
+++ b/src/lib/cyber-icon-jsx.tsx
@@ -2,7 +2,6 @@ export function cyberIconJsx(size: number) {
   const isSmall = size <= 48
   const dotSpacing = isSmall ? 4 : 12
   const dotRadius = isSmall ? 0.5 : 1
-  const borderWidth = isSmall ? 2 : Math.max(4, Math.floor(size / 64))
   const checkSize = Math.floor(size * 0.58)
   const strokeWidth = isSmall ? 2 : 2.5
 
@@ -17,8 +16,6 @@ export function cyberIconJsx(size: number) {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        border: `${borderWidth}px solid rgba(255,0,204,0.8)`,
-        boxSizing: "border-box",
       }}
     >
       <svg


### PR DESCRIPTION
## Summary
- サイバー・ドット風デザインのアイコンを実装 (ドットグリッド背景 + マゼンタチェックマーク)
- `icon.tsx`: Next.js ImageResponse で生成する 32x32 ブラウザfavicon
- `apple-icon.tsx`: 180x180 Apple touchアイコン
- `icon.svg`: PWAマニフェスト用スケーラブルSVGアイコン
- `manifest.ts`: PWAマニフェスト (display: standalone, theme_color: #ff00cc)
- `layout.tsx`: `themeColor` 追加 + DotGothic16 の Japanese サブセット有効化
- `globals.css`: `font-family` 重複指定を削除

## Test plan
- [ ] ブラウザタブにマゼンタのチェックマークfaviconが表示される
- [ ] Androidでホーム画面に追加するとサイバードット風アイコンが表示される
- [ ] iOSでホーム画面に追加するとApple touchアイコンが表示される
- [ ] `<meta name="theme-color">` にマゼンタ (#ff00cc) が設定されている
- [ ] `/manifest.webmanifest` が正しく返される

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)