### PR TITLE
feat: タスクページ本文の閲覧・Markdown編集機能を追加

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath, revalidateTag } from "next/cache"
 import { cookies } from "next/headers"
 import { auth } from "@/auth"
-import { updateTask, createTask } from "@/lib/notion"
+import { updateTask, createTask, getTaskBlocks, updateTaskBlocks } from "@/lib/notion"
 import type { TaskStatus, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 
 async function requireAuth() {
@@ -46,4 +46,14 @@ export async function refreshTasksAction() {
   await requireAuth()
   revalidateTag("tasks", "default")
   revalidatePath("/")
+}
+
+export async function getTaskBlocksAction(id: string): Promise<string> {
+  await requireAuth()
+  return getTaskBlocks(id)
+}
+
+export async function updateTaskBlocksAction(id: string, markdown: string): Promise<void> {
+  await requireAuth()
+  await updateTaskBlocks(id, markdown)
 }

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useTransition, useState, useEffect } from "react"
+import { useTransition, useState, useEffect, useRef } from "react"
 import type { Task, TaskStatus, TaskPriority, TaskTag } from "@/types/task"
-import { updateTaskAction } from "@/app/actions"
+import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction } from "@/app/actions"
 import { STATUS_OPTIONS, STATUS_STYLES } from "@/constants/styles"
 
 const TAG_OPTIONS: TaskTag[] = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
@@ -17,9 +17,24 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
   const [editDue, setEditDue] = useState(task.due ?? "")
   const [editTags, setEditTags] = useState<TaskTag[]>(task.tags)
 
+  const [blocks, setBlocks] = useState<string | null>(null)
+  const [isLoadingBlocks, setIsLoadingBlocks] = useState(true)
+  const [isEditingBlocks, setIsEditingBlocks] = useState(false)
+  const [editBlocksContent, setEditBlocksContent] = useState("")
+  const [isSavingBlocks, setIsSavingBlocks] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
   useEffect(() => {
     requestAnimationFrame(() => setVisible(true))
   }, [])
+
+  useEffect(() => {
+    setIsLoadingBlocks(true)
+    getTaskBlocksAction(task.id).then((md) => {
+      setBlocks(md)
+      setIsLoadingBlocks(false)
+    })
+  }, [task.id])
 
   function handleClose() {
     setVisible(false)
@@ -184,6 +199,78 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
           )}
         </div>
 
+        {/* 本文 */}
+        <div className="mt-6">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs text-[#996688] tracking-widest uppercase">本文</p>
+            {!isLoadingBlocks && !isEditingBlocks && (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditBlocksContent(blocks ?? "")
+                  setIsEditingBlocks(true)
+                  setTimeout(() => textareaRef.current?.focus(), 50)
+                }}
+                className="text-xs text-[#996688] hover:text-[#ff00cc] transition-colors tracking-widest uppercase"
+              >
+                編集
+              </button>
+            )}
+          </div>
+
+          {isLoadingBlocks ? (
+            <div className="flex justify-center py-4">
+              <div className="w-5 h-5 rounded-full border-2 border-[rgba(255,0,204,0.3)] border-t-[#ff00cc] animate-spin" />
+            </div>
+          ) : isEditingBlocks ? (
+            <div>
+              <textarea
+                ref={textareaRef}
+                value={editBlocksContent}
+                onChange={(e) => {
+                  setEditBlocksContent(e.target.value)
+                  // auto-resize
+                  const el = e.target
+                  el.style.height = "auto"
+                  el.style.height = `${el.scrollHeight}px`
+                }}
+                className="w-full rounded-xl px-4 py-3 text-sm text-[#ffbbee] bg-[#0d0014] focus:outline-none focus:border-[#ff00cc] resize-none min-h-[120px] font-mono"
+                style={{ border: "1px solid rgba(255,0,204,0.3)" }}
+                placeholder="Markdownで入力（# 見出し、- リスト など）"
+              />
+              <div className="flex gap-2 mt-2 justify-end">
+                <button
+                  type="button"
+                  onClick={() => setIsEditingBlocks(false)}
+                  className="px-4 py-1.5 rounded-xl text-xs text-[#996688] hover:text-[#ffbbee] transition-colors"
+                  style={{ border: "1px solid rgba(255,0,204,0.2)" }}
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="button"
+                  disabled={isSavingBlocks}
+                  onClick={async () => {
+                    setIsSavingBlocks(true)
+                    await updateTaskBlocksAction(task.id, editBlocksContent)
+                    setBlocks(editBlocksContent)
+                    setIsEditingBlocks(false)
+                    setIsSavingBlocks(false)
+                  }}
+                  className="px-4 py-1.5 rounded-xl text-xs text-[#0d0014] transition-all"
+                  style={{ backgroundColor: isSavingBlocks ? "rgba(255,0,204,0.5)" : "#ff00cc" }}
+                >
+                  {isSavingBlocks ? "保存中…" : "保存"}
+                </button>
+              </div>
+            </div>
+          ) : blocks ? (
+            <MarkdownPreview content={blocks} />
+          ) : (
+            <p className="text-xs text-[#553355] italic">本文なし</p>
+          )}
+        </div>
+
         {/* Notion link */}
         <a
           href={task.url}
@@ -206,4 +293,81 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
       <div className="flex-1">{children}</div>
     </div>
   )
+}
+
+function MarkdownPreview({ content }: { content: string }) {
+  const lines = content.split("\n")
+  let inCode = false
+  const codeLines: string[] = []
+  const elements: React.ReactNode[] = []
+
+  const flushCode = (key: number) => {
+    elements.push(
+      <pre
+        key={key}
+        className="rounded-lg px-3 py-2 text-xs text-[#ffbbee] font-mono overflow-x-auto my-1"
+        style={{ backgroundColor: "rgba(0,0,0,0.4)", border: "1px solid rgba(255,0,204,0.15)" }}
+      >
+        {codeLines.join("\n")}
+      </pre>
+    )
+    codeLines.length = 0
+  }
+
+  lines.forEach((line, i) => {
+    if (line.startsWith("```")) {
+      if (inCode) {
+        flushCode(i)
+        inCode = false
+      } else {
+        inCode = true
+      }
+      return
+    }
+    if (inCode) {
+      codeLines.push(line)
+      return
+    }
+
+    if (line === "---") {
+      elements.push(<hr key={i} className="my-2 border-[rgba(255,0,204,0.2)]" />)
+    } else if (line.startsWith("# ")) {
+      elements.push(<p key={i} className="text-[#ffbbee] text-base font-bold mt-2 mb-0.5">{line.slice(2)}</p>)
+    } else if (line.startsWith("## ")) {
+      elements.push(<p key={i} className="text-[#ffbbee] text-sm font-semibold mt-1.5 mb-0.5">{line.slice(3)}</p>)
+    } else if (line.startsWith("### ")) {
+      elements.push(<p key={i} className="text-[#cc99bb] text-sm font-medium mt-1 mb-0.5">{line.slice(4)}</p>)
+    } else if (/^- \[x\] /i.test(line)) {
+      elements.push(
+        <p key={i} className="text-[#996688] text-sm line-through">
+          <span className="mr-1.5 not-italic">☑</span>{line.slice(6)}
+        </p>
+      )
+    } else if (/^- \[ \] /.test(line)) {
+      elements.push(
+        <p key={i} className="text-[#cc99bb] text-sm">
+          <span className="mr-1.5">☐</span>{line.slice(6)}
+        </p>
+      )
+    } else if (line.startsWith("- ") || line.startsWith("* ")) {
+      elements.push(<p key={i} className="text-[#cc99bb] text-sm"><span className="mr-1.5 text-[#ff00cc]">・</span>{line.slice(2)}</p>)
+    } else if (/^\d+\. /.test(line)) {
+      const match = line.match(/^(\d+)\. (.*)/)
+      elements.push(<p key={i} className="text-[#cc99bb] text-sm"><span className="mr-1.5 text-[#ff00cc]">{match?.[1]}.</span>{match?.[2]}</p>)
+    } else if (line.startsWith("> ")) {
+      elements.push(
+        <p key={i} className="text-[#996688] text-sm pl-3 italic" style={{ borderLeft: "2px solid rgba(255,0,204,0.4)" }}>
+          {line.slice(2)}
+        </p>
+      )
+    } else if (line === "") {
+      elements.push(<div key={i} className="h-2" />)
+    } else {
+      elements.push(<p key={i} className="text-[#cc99bb] text-sm">{line}</p>)
+    }
+  })
+
+  if (inCode && codeLines.length > 0) flushCode(lines.length)
+
+  return <div className="space-y-0.5">{elements}</div>
 }

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -22,6 +22,8 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
   const [isEditingBlocks, setIsEditingBlocks] = useState(false)
   const [editBlocksContent, setEditBlocksContent] = useState("")
   const [isSavingBlocks, setIsSavingBlocks] = useState(false)
+  const [blocksLoadError, setBlocksLoadError] = useState<string | null>(null)
+  const [blocksSaveError, setBlocksSaveError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
@@ -29,12 +31,58 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
   }, [])
 
   useEffect(() => {
-    setIsLoadingBlocks(true)
-    getTaskBlocksAction(task.id).then((md) => {
-      setBlocks(md)
-      setIsLoadingBlocks(false)
-    })
+    let cancelled = false
+
+    async function loadBlocks() {
+      setBlocks(null)
+      setIsLoadingBlocks(true)
+      setIsEditingBlocks(false)
+      setIsSavingBlocks(false)
+      setBlocksLoadError(null)
+      setBlocksSaveError(null)
+
+      try {
+        const md = await getTaskBlocksAction(task.id)
+        if (cancelled) return
+        setBlocks(md)
+      } catch {
+        if (cancelled) return
+        setBlocks("")
+        setBlocksLoadError("本文の読み込みに失敗しました。")
+      } finally {
+        if (cancelled) return
+        setIsLoadingBlocks(false)
+      }
+    }
+
+    void loadBlocks()
+
+    return () => {
+      cancelled = true
+    }
   }, [task.id])
+
+  function startEditingBlocks() {
+    setEditBlocksContent(blocks ?? "")
+    setBlocksSaveError(null)
+    setIsEditingBlocks(true)
+    setTimeout(() => textareaRef.current?.focus(), 50)
+  }
+
+  async function handleSaveBlocks() {
+    setIsSavingBlocks(true)
+    setBlocksSaveError(null)
+
+    try {
+      await updateTaskBlocksAction(task.id, editBlocksContent)
+      setBlocks(editBlocksContent)
+      setIsEditingBlocks(false)
+    } catch {
+      setBlocksSaveError("本文の保存に失敗しました。")
+    } finally {
+      setIsSavingBlocks(false)
+    }
+  }
 
   function handleClose() {
     setVisible(false)
@@ -206,17 +254,17 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
             {!isLoadingBlocks && !isEditingBlocks && (
               <button
                 type="button"
-                onClick={() => {
-                  setEditBlocksContent(blocks ?? "")
-                  setIsEditingBlocks(true)
-                  setTimeout(() => textareaRef.current?.focus(), 50)
-                }}
+                onClick={startEditingBlocks}
                 className="text-xs text-[#996688] hover:text-[#ff00cc] transition-colors tracking-widest uppercase"
               >
                 編集
               </button>
             )}
           </div>
+
+          {blocksLoadError && !isEditingBlocks && (
+            <p className="mb-2 text-xs text-[#ff77aa]">{blocksLoadError}</p>
+          )}
 
           {isLoadingBlocks ? (
             <div className="flex justify-center py-4">
@@ -241,7 +289,10 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
               <div className="flex gap-2 mt-2 justify-end">
                 <button
                   type="button"
-                  onClick={() => setIsEditingBlocks(false)}
+                  onClick={() => {
+                    setBlocksSaveError(null)
+                    setIsEditingBlocks(false)
+                  }}
                   className="px-4 py-1.5 rounded-xl text-xs text-[#996688] hover:text-[#ffbbee] transition-colors"
                   style={{ border: "1px solid rgba(255,0,204,0.2)" }}
                 >
@@ -250,19 +301,16 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
                 <button
                   type="button"
                   disabled={isSavingBlocks}
-                  onClick={async () => {
-                    setIsSavingBlocks(true)
-                    await updateTaskBlocksAction(task.id, editBlocksContent)
-                    setBlocks(editBlocksContent)
-                    setIsEditingBlocks(false)
-                    setIsSavingBlocks(false)
-                  }}
+                  onClick={handleSaveBlocks}
                   className="px-4 py-1.5 rounded-xl text-xs text-[#0d0014] transition-all"
                   style={{ backgroundColor: isSavingBlocks ? "rgba(255,0,204,0.5)" : "#ff00cc" }}
                 >
                   {isSavingBlocks ? "保存中…" : "保存"}
                 </button>
               </div>
+              {blocksSaveError && (
+                <p className="mt-2 text-xs text-[#ff77aa]">{blocksSaveError}</p>
+              )}
             </div>
           ) : blocks ? (
             <MarkdownPreview content={blocks} />

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { TaskDetail } from "@/components/TaskDetail"
+import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction } from "@/app/actions"
 import type { Task } from "@/types/task"
 
 vi.mock("@/app/actions", () => ({
@@ -11,10 +12,14 @@ vi.mock("@/app/actions", () => ({
 
 // requestAnimationFrame を同期実行してアニメーション初期化を完了させる
 beforeEach(() => {
+  vi.clearAllMocks()
   vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
     cb(0)
     return 0
   })
+  vi.mocked(updateTaskAction).mockResolvedValue(undefined)
+  vi.mocked(getTaskBlocksAction).mockResolvedValue("")
+  vi.mocked(updateTaskBlocksAction).mockResolvedValue(undefined)
 })
 
 afterEach(() => {
@@ -41,6 +46,18 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     lastEditedTime: "2024-01-01T00:00:00.000Z",
     ...overrides,
   }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
 }
 
 describe("TaskDetail レンダリング", () => {
@@ -133,7 +150,6 @@ describe("TaskDetail レンダリング", () => {
 
 describe("TaskDetail フィールド変更", () => {
   it("ステータス変更で updateTaskAction が即時呼ばれる", async () => {
-    const { updateTaskAction } = await import("@/app/actions")
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
@@ -157,7 +173,6 @@ describe("TaskDetail フィールド変更", () => {
   })
 
   it("Priority 変更で updateTaskAction が即時呼ばれる", async () => {
-    const { updateTaskAction } = await import("@/app/actions")
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
@@ -171,7 +186,6 @@ describe("TaskDetail フィールド変更", () => {
   })
 
   it("タグトグルで updateTaskAction が即時呼ばれる", async () => {
-    const { updateTaskAction } = await import("@/app/actions")
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
@@ -184,7 +198,6 @@ describe("TaskDetail フィールド変更", () => {
   })
 
   it("タイトル blur で updateTaskAction が呼ばれる", async () => {
-    const { updateTaskAction } = await import("@/app/actions")
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
@@ -196,6 +209,96 @@ describe("TaskDetail フィールド変更", () => {
     await waitFor(() => {
       expect(mock).toHaveBeenCalledWith("t1", { title: "新タイトル" })
     })
+  })
+})
+
+describe("TaskDetail 本文編集", () => {
+  it("取得した本文を表示する", async () => {
+    vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("## 本文見出し\n\n- 箇条書き")
+
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+
+    expect(await screen.findByText("本文見出し")).toBeInTheDocument()
+    expect(screen.getByText("箇条書き")).toBeInTheDocument()
+  })
+
+  it("編集して保存すると updateTaskBlocksAction が呼ばれる", async () => {
+    const updateBlocksMock = vi.mocked(updateTaskBlocksAction)
+    vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("元の本文")
+
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+
+    await screen.findByText("元の本文")
+    fireEvent.click(screen.getByRole("button", { name: "編集" }))
+    fireEvent.change(screen.getByPlaceholderText("Markdownで入力（# 見出し、- リスト など）"), {
+      target: { value: "更新後の本文" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "保存" }))
+
+    await waitFor(() => {
+      expect(updateBlocksMock).toHaveBeenCalledWith("t1", "更新後の本文")
+    })
+
+    expect(await screen.findByText("更新後の本文")).toBeInTheDocument()
+  })
+
+  it("本文取得に失敗してもローディングから復帰する", async () => {
+    vi.mocked(getTaskBlocksAction).mockRejectedValueOnce(new Error("load failed"))
+
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+
+    expect(await screen.findByText("本文の読み込みに失敗しました。")).toBeInTheDocument()
+    expect(screen.getByText("本文なし")).toBeInTheDocument()
+  })
+
+  it("本文保存に失敗しても編集中のまま復帰する", async () => {
+    vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("元の本文")
+    vi.mocked(updateTaskBlocksAction).mockRejectedValueOnce(new Error("save failed"))
+
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+
+    await screen.findByText("元の本文")
+    fireEvent.click(screen.getByRole("button", { name: "編集" }))
+    fireEvent.change(screen.getByPlaceholderText("Markdownで入力（# 見出し、- リスト など）"), {
+      target: { value: "保存失敗本文" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "保存" }))
+
+    expect(await screen.findByText("本文の保存に失敗しました。")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("保存失敗本文")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "保存" })).not.toBeDisabled()
+    })
+  })
+
+  it("task.id 切り替え後に古い本文取得結果で上書きしない", async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+
+    vi.mocked(getTaskBlocksAction).mockImplementation((id: string) => {
+      if (id === "t1") return first.promise
+      if (id === "t2") return second.promise
+      return Promise.resolve("")
+    })
+
+    const { rerender } = render(<TaskDetail task={makeTask({ id: "t1" })} onClose={() => {}} />)
+
+    rerender(<TaskDetail task={makeTask({ id: "t2", url: "https://notion.so/t2" })} onClose={() => {}} />)
+
+    await act(async () => {
+      second.resolve("新しい本文")
+    })
+
+    expect(await screen.findByText("新しい本文")).toBeInTheDocument()
+
+    await act(async () => {
+      first.resolve("古い本文")
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText("古い本文")).not.toBeInTheDocument()
+    })
+    expect(screen.getByText("新しい本文")).toBeInTheDocument()
   })
 })
 

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -5,6 +5,8 @@ import type { Task } from "@/types/task"
 
 vi.mock("@/app/actions", () => ({
   updateTaskAction: vi.fn().mockResolvedValue(undefined),
+  getTaskBlocksAction: vi.fn().mockResolvedValue(""),
+  updateTaskBlocksAction: vi.fn().mockResolvedValue(undefined),
 }))
 
 // requestAnimationFrame を同期実行してアニメーション初期化を完了させる

--- a/src/lib/mock-tasks.ts
+++ b/src/lib/mock-tasks.ts
@@ -152,6 +152,11 @@ const INITIAL_TASKS: Task[] = [
 let store: Task[] = INITIAL_TASKS.map((t) => ({ ...t }))
 let nextId = 100
 
+const mockBlockStore = new Map<string, string>([
+  ["mock-1", "## 作業メモ\n\n- ファームウェアバージョン確認\n- バックアップ取得後に適用"],
+  ["mock-2", "## 構成\n\n- 導入\n- 本題\n- まとめ"],
+])
+
 export function resetMockTasks() {
   store = INITIAL_TASKS.map((t) => ({ ...t }))
   nextId = 100
@@ -188,6 +193,14 @@ export function createMockTask(input: CreateTaskInput): Task {
   }
   store.push(task)
   return task
+}
+
+export function getMockTaskBlocks(id: string): string {
+  return mockBlockStore.get(id) ?? ""
+}
+
+export function updateMockTaskBlocks(id: string, content: string): void {
+  mockBlockStore.set(id, content)
 }
 
 export function updateMockTask(id: string, input: UpdateTaskInput): Task | null {

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,6 +1,6 @@
 import { unstable_cache } from "next/cache"
 import { Client } from "@notionhq/client"
-import type { PageObjectResponse, BlockObjectResponse } from "@notionhq/client/build/src/api-endpoints"
+import type { PageObjectResponse, BlockObjectResponse, PartialBlockObjectResponse } from "@notionhq/client/build/src/api-endpoints"
 import type { Task, TaskPriority, TaskStatus, TaskTag, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 import { NOTION_PROPS } from "@/constants/notion"
 import { config } from "@/config"
@@ -184,9 +184,14 @@ function extractPlainText(richText: Array<{ plain_text: string }>): string {
   return richText.map((r) => r.plain_text).join("")
 }
 
+function isFullBlockObjectResponse(
+  block: BlockObjectResponse | PartialBlockObjectResponse
+): block is BlockObjectResponse {
+  return "type" in block
+}
+
 function blocksToMarkdown(blocks: BlockObjectResponse[]): string {
   const lines: string[] = []
-  let inCode = false
 
   for (const block of blocks) {
     const b = block as Record<string, unknown>
@@ -230,9 +235,6 @@ function blocksToMarkdown(blocks: BlockObjectResponse[]): string {
       if (inner?.rich_text) lines.push(extractPlainText(inner.rich_text))
     }
   }
-
-  // suppress unused variable warning
-  void inCode
 
   return lines.join("\n")
 }
@@ -305,7 +307,7 @@ export async function getTaskBlocks(id: string): Promise<string> {
         page_size: 100,
         ...(cursor ? { start_cursor: cursor } : {}),
       })
-      allBlocks.push(...(response.results as BlockObjectResponse[]))
+      allBlocks.push(...response.results.filter(isFullBlockObjectResponse))
       cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
     } while (cursor)
 

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,10 +1,10 @@
 import { unstable_cache } from "next/cache"
 import { Client } from "@notionhq/client"
-import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints"
+import type { PageObjectResponse, BlockObjectResponse } from "@notionhq/client/build/src/api-endpoints"
 import type { Task, TaskPriority, TaskStatus, TaskTag, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 import { NOTION_PROPS } from "@/constants/notion"
 import { config } from "@/config"
-import { getMockTasks, getMockTask, createMockTask, updateMockTask } from "@/lib/mock-tasks"
+import { getMockTasks, getMockTask, createMockTask, updateMockTask, getMockTaskBlocks, updateMockTaskBlocks } from "@/lib/mock-tasks"
 
 const IS_DEV = process.env.NODE_ENV === "development"
 
@@ -176,4 +176,176 @@ export async function updateTask(id: string, input: UpdateTaskInput): Promise<Ta
   })
 
   return pageToTask(page as PageObjectResponse)
+}
+
+// --- Block content helpers ---
+
+function extractPlainText(richText: Array<{ plain_text: string }>): string {
+  return richText.map((r) => r.plain_text).join("")
+}
+
+function blocksToMarkdown(blocks: BlockObjectResponse[]): string {
+  const lines: string[] = []
+  let inCode = false
+
+  for (const block of blocks) {
+    const b = block as Record<string, unknown>
+    const type = b.type as string
+
+    if (type === "heading_1") {
+      const rt = (b["heading_1"] as { rich_text: Array<{ plain_text: string }> }).rich_text
+      lines.push(`# ${extractPlainText(rt)}`)
+    } else if (type === "heading_2") {
+      const rt = (b["heading_2"] as { rich_text: Array<{ plain_text: string }> }).rich_text
+      lines.push(`## ${extractPlainText(rt)}`)
+    } else if (type === "heading_3") {
+      const rt = (b["heading_3"] as { rich_text: Array<{ plain_text: string }> }).rich_text
+      lines.push(`### ${extractPlainText(rt)}`)
+    } else if (type === "bulleted_list_item") {
+      const rt = (b["bulleted_list_item"] as { rich_text: Array<{ plain_text: string }> }).rich_text
+      lines.push(`- ${extractPlainText(rt)}`)
+    } else if (type === "numbered_list_item") {
+      const rt = (b["numbered_list_item"] as { rich_text: Array<{ plain_text: string }> }).rich_text
+      lines.push(`1. ${extractPlainText(rt)}`)
+    } else if (type === "to_do") {
+      const td = b["to_do"] as { rich_text: Array<{ plain_text: string }>; checked: boolean }
+      const check = td.checked ? "[x]" : "[ ]"
+      lines.push(`- ${check} ${extractPlainText(td.rich_text)}`)
+    } else if (type === "quote") {
+      const rt = (b["quote"] as { rich_text: Array<{ plain_text: string }> }).rich_text
+      lines.push(`> ${extractPlainText(rt)}`)
+    } else if (type === "code") {
+      const cd = b["code"] as { rich_text: Array<{ plain_text: string }>; language?: string }
+      lines.push("```")
+      lines.push(extractPlainText(cd.rich_text))
+      lines.push("```")
+    } else if (type === "divider") {
+      lines.push("---")
+    } else if (type === "paragraph") {
+      const rt = (b["paragraph"] as { rich_text: Array<{ plain_text: string }> }).rich_text
+      lines.push(extractPlainText(rt))
+    } else {
+      // fallback: try to extract any rich_text
+      const inner = b[type] as { rich_text?: Array<{ plain_text: string }> } | undefined
+      if (inner?.rich_text) lines.push(extractPlainText(inner.rich_text))
+    }
+  }
+
+  // suppress unused variable warning
+  void inCode
+
+  return lines.join("\n")
+}
+
+function markdownToNotionBlocks(markdown: string): object[] {
+  const blocks: object[] = []
+  const lines = markdown.split("\n")
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+
+    // Fenced code block
+    if (line.startsWith("```")) {
+      const codeLines: string[] = []
+      i++
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        codeLines.push(lines[i])
+        i++
+      }
+      blocks.push({
+        type: "code",
+        code: {
+          rich_text: [{ type: "text", text: { content: codeLines.join("\n") } }],
+          language: "plain text",
+        },
+      })
+      i++ // skip closing ```
+      continue
+    }
+
+    if (line === "---") {
+      blocks.push({ type: "divider", divider: {} })
+    } else if (line.startsWith("# ")) {
+      blocks.push({ type: "heading_1", heading_1: { rich_text: [{ type: "text", text: { content: line.slice(2) } }] } })
+    } else if (line.startsWith("## ")) {
+      blocks.push({ type: "heading_2", heading_2: { rich_text: [{ type: "text", text: { content: line.slice(3) } }] } })
+    } else if (line.startsWith("### ")) {
+      blocks.push({ type: "heading_3", heading_3: { rich_text: [{ type: "text", text: { content: line.slice(4) } }] } })
+    } else if (/^- \[x\] /i.test(line)) {
+      blocks.push({ type: "to_do", to_do: { rich_text: [{ type: "text", text: { content: line.slice(6) } }], checked: true } })
+    } else if (/^- \[ \] /.test(line)) {
+      blocks.push({ type: "to_do", to_do: { rich_text: [{ type: "text", text: { content: line.slice(6) } }], checked: false } })
+    } else if (line.startsWith("- ") || line.startsWith("* ")) {
+      blocks.push({ type: "bulleted_list_item", bulleted_list_item: { rich_text: [{ type: "text", text: { content: line.slice(2) } }] } })
+    } else if (/^\d+\. /.test(line)) {
+      const content = line.replace(/^\d+\. /, "")
+      blocks.push({ type: "numbered_list_item", numbered_list_item: { rich_text: [{ type: "text", text: { content } }] } })
+    } else if (line.startsWith("> ")) {
+      blocks.push({ type: "quote", quote: { rich_text: [{ type: "text", text: { content: line.slice(2) } }] } })
+    } else {
+      blocks.push({ type: "paragraph", paragraph: { rich_text: [{ type: "text", text: { content: line } }] } })
+    }
+
+    i++
+  }
+
+  return blocks
+}
+
+export async function getTaskBlocks(id: string): Promise<string> {
+  if (IS_DEV) return getMockTaskBlocks(id)
+  try {
+    const allBlocks: BlockObjectResponse[] = []
+    let cursor: string | undefined = undefined
+
+    do {
+      const response = await notion.blocks.children.list({
+        block_id: id,
+        page_size: 100,
+        ...(cursor ? { start_cursor: cursor } : {}),
+      })
+      allBlocks.push(...(response.results as BlockObjectResponse[]))
+      cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
+    } while (cursor)
+
+    return blocksToMarkdown(allBlocks)
+  } catch (e) {
+    console.error("[getTaskBlocks] Notion error:", e)
+    return ""
+  }
+}
+
+export async function updateTaskBlocks(id: string, markdown: string): Promise<void> {
+  if (IS_DEV) {
+    updateMockTaskBlocks(id, markdown)
+    return
+  }
+  try {
+    // Fetch and delete existing blocks
+    let cursor: string | undefined = undefined
+    do {
+      const response = await notion.blocks.children.list({
+        block_id: id,
+        page_size: 100,
+        ...(cursor ? { start_cursor: cursor } : {}),
+      })
+      for (const block of response.results) {
+        await notion.blocks.delete({ block_id: block.id })
+      }
+      cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
+    } while (cursor)
+
+    // Append new blocks from markdown
+    const newBlocks = markdownToNotionBlocks(markdown)
+    if (newBlocks.length > 0) {
+      await notion.blocks.children.append({
+        block_id: id,
+        children: newBlocks as Parameters<typeof notion.blocks.children.append>[0]["children"],
+      })
+    }
+  } catch (e) {
+    console.error("[updateTaskBlocks] Notion error:", e)
+    throw e
+  }
 }


### PR DESCRIPTION
## 概要
- タスク詳細ページで本文を表示できるように変更
- Markdown形式で本文を編集・保存できるように変更
- Notion連携とモックデータを本文対応に更新
