### PR TITLE
fix: スワイプダウンでタスク詳細を閉じるよう修正

### DIFF
--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useTransition, useState, useEffect, useRef, useCallback } from "react"
+import { useTransition, useState, useEffect, useRef } from "react"
 import type { Task, TaskStatus, TaskPriority, TaskTag } from "@/types/task"
 import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction } from "@/app/actions"
 import { STATUS_OPTIONS, STATUS_STYLES } from "@/constants/styles"
@@ -29,8 +29,7 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
   const touchStartYRef = useRef(0)
   const dragYRef = useRef(0)
   const isDraggingRef = useRef(false)
-  const [dragOffset, setDragOffset] = useState(0)
-  const [isDragging, setIsDragging] = useState(false)
+  const rafIdRef = useRef(0)
   const isEditingBlocksRef = useRef(isEditingBlocks)
   useEffect(() => { isEditingBlocksRef.current = isEditingBlocks }, [isEditingBlocks])
 
@@ -45,18 +44,23 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
     return () => { document.body.style.overflow = prev }
   }, [])
 
-  const handleCloseRef = useRef<() => void>(() => {})
+  // パネルの open/close アニメーションを直接 DOM に適用
+  useEffect(() => {
+    const el = panelRef.current
+    if (!el) return
+    el.style.transition = "opacity 0.15s, transform 0.3s ease-out"
+    el.style.transform = visible ? "translateY(0)" : "translateY(100%)"
+  }, [visible])
 
-  const handleCloseCb = useCallback(() => {
+  // handleClose — レンダー中に ref へ同期代入することでレースコンディションを回避
+  const handleCloseRef = useRef<() => void>(() => {})
+  function handleClose() {
     setVisible(false)
     setTimeout(onClose, 280)
-  }, [onClose])
+  }
+  handleCloseRef.current = handleClose
 
-  useEffect(() => {
-    handleCloseRef.current = handleCloseCb
-  }, [handleCloseCb])
-
-  // スワイプダウンで閉じる
+  // スワイプダウンで閉じる（rAF で描画を間引き、setState なしで直接 DOM 操作）
   useEffect(() => {
     const panel = panelRef.current
     if (!panel) return
@@ -74,27 +78,31 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
       const deltaY = e.touches[0].clientY - touchStartYRef.current
       if (deltaY <= 0) return
       if (el.scrollTop > 0) return
-      // textarea 編集中は無効
       if (isEditingBlocksRef.current) return
 
       isDraggingRef.current = true
       dragYRef.current = deltaY
       e.preventDefault()
-      setIsDragging(true)
-      setDragOffset(deltaY)
+
+      cancelAnimationFrame(rafIdRef.current)
+      rafIdRef.current = requestAnimationFrame(() => {
+        el.style.transition = "opacity 0.15s"
+        el.style.transform = `translateY(${deltaY}px)`
+      })
     }
 
     function onTouchEnd() {
       if (!isDraggingRef.current) return
+      cancelAnimationFrame(rafIdRef.current)
       const delta = dragYRef.current
       isDraggingRef.current = false
       dragYRef.current = 0
-      setIsDragging(false)
 
       if (delta >= THRESHOLD) {
         handleCloseRef.current()
       } else {
-        setDragOffset(0)
+        el.style.transition = "opacity 0.15s, transform 0.3s ease-out"
+        el.style.transform = "translateY(0)"
       }
     }
 
@@ -103,6 +111,7 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
     el.addEventListener("touchend", onTouchEnd, { passive: true })
 
     return () => {
+      cancelAnimationFrame(rafIdRef.current)
       el.removeEventListener("touchstart", onTouchStart)
       el.removeEventListener("touchmove", onTouchMove)
       el.removeEventListener("touchend", onTouchEnd)
@@ -163,10 +172,6 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
     }
   }
 
-  function handleClose() {
-    handleCloseCb()
-  }
-
   function save(input: Parameters<typeof updateTaskAction>[1]) {
     startTransition(async () => {
       await updateTaskAction(task.id, input)
@@ -207,18 +212,13 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
 
       <div
         ref={panelRef}
-        className={`relative rounded-t-2xl px-5 pt-4 pb-10 max-h-[85svh] overflow-y-auto ${isDragging ? "" : "transition-transform duration-300 ease-out"} ${visible && !isDragging ? "translate-y-0" : isDragging ? "" : "translate-y-full"}`}
+        className="relative rounded-t-2xl px-5 pt-4 pb-10 max-h-[85svh] overflow-y-auto"
         style={{
           backgroundColor: "#160022",
           borderTop: "1px solid rgba(255,0,204,0.5)",
           boxShadow: "0 -4px 30px rgba(255,0,204,0.2)",
           opacity: isPending ? 0.85 : 1,
-          transition: isDragging ? "opacity 0.15s" : "opacity 0.15s, transform 0.3s ease-out",
-          transform: isDragging
-            ? `translateY(${dragOffset}px)`
-            : visible
-              ? "translateY(0)"
-              : "translateY(100%)",
+          transition: "opacity 0.15s",
         }}
       >
         {/* Handle */}

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useTransition, useState, useEffect, useRef } from "react"
+import { useTransition, useState, useEffect, useRef, useCallback } from "react"
 import type { Task, TaskStatus, TaskPriority, TaskTag } from "@/types/task"
 import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction } from "@/app/actions"
 import { STATUS_OPTIONS, STATUS_STYLES } from "@/constants/styles"
@@ -25,9 +25,88 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
   const [blocksLoadError, setBlocksLoadError] = useState<string | null>(null)
   const [blocksSaveError, setBlocksSaveError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const touchStartYRef = useRef(0)
+  const dragYRef = useRef(0)
+  const isDraggingRef = useRef(false)
+  const [dragOffset, setDragOffset] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
+  const isEditingBlocksRef = useRef(isEditingBlocks)
+  useEffect(() => { isEditingBlocksRef.current = isEditingBlocks }, [isEditingBlocks])
 
   useEffect(() => {
     requestAnimationFrame(() => setVisible(true))
+  }, [])
+
+  // 背景スクロール抑制
+  useEffect(() => {
+    const prev = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => { document.body.style.overflow = prev }
+  }, [])
+
+  const handleCloseRef = useRef<() => void>(() => {})
+
+  const handleCloseCb = useCallback(() => {
+    setVisible(false)
+    setTimeout(onClose, 280)
+  }, [onClose])
+
+  useEffect(() => {
+    handleCloseRef.current = handleCloseCb
+  }, [handleCloseCb])
+
+  // スワイプダウンで閉じる
+  useEffect(() => {
+    const panel = panelRef.current
+    if (!panel) return
+    const el = panel
+
+    const THRESHOLD = 80
+
+    function onTouchStart(e: TouchEvent) {
+      touchStartYRef.current = e.touches[0].clientY
+      isDraggingRef.current = false
+      dragYRef.current = 0
+    }
+
+    function onTouchMove(e: TouchEvent) {
+      const deltaY = e.touches[0].clientY - touchStartYRef.current
+      if (deltaY <= 0) return
+      if (el.scrollTop > 0) return
+      // textarea 編集中は無効
+      if (isEditingBlocksRef.current) return
+
+      isDraggingRef.current = true
+      dragYRef.current = deltaY
+      e.preventDefault()
+      setIsDragging(true)
+      setDragOffset(deltaY)
+    }
+
+    function onTouchEnd() {
+      if (!isDraggingRef.current) return
+      const delta = dragYRef.current
+      isDraggingRef.current = false
+      dragYRef.current = 0
+      setIsDragging(false)
+
+      if (delta >= THRESHOLD) {
+        handleCloseRef.current()
+      } else {
+        setDragOffset(0)
+      }
+    }
+
+    el.addEventListener("touchstart", onTouchStart, { passive: true })
+    el.addEventListener("touchmove", onTouchMove, { passive: false })
+    el.addEventListener("touchend", onTouchEnd, { passive: true })
+
+    return () => {
+      el.removeEventListener("touchstart", onTouchStart)
+      el.removeEventListener("touchmove", onTouchMove)
+      el.removeEventListener("touchend", onTouchEnd)
+    }
   }, [])
 
   useEffect(() => {
@@ -85,8 +164,7 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
   }
 
   function handleClose() {
-    setVisible(false)
-    setTimeout(onClose, 280)
+    handleCloseCb()
   }
 
   function save(input: Parameters<typeof updateTaskAction>[1]) {
@@ -128,13 +206,19 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
       />
 
       <div
-        className={`relative rounded-t-2xl px-5 pt-4 pb-10 max-h-[85svh] overflow-y-auto transition-transform duration-300 ease-out ${visible ? "translate-y-0" : "translate-y-full"}`}
+        ref={panelRef}
+        className={`relative rounded-t-2xl px-5 pt-4 pb-10 max-h-[85svh] overflow-y-auto ${isDragging ? "" : "transition-transform duration-300 ease-out"} ${visible && !isDragging ? "translate-y-0" : isDragging ? "" : "translate-y-full"}`}
         style={{
           backgroundColor: "#160022",
           borderTop: "1px solid rgba(255,0,204,0.5)",
           boxShadow: "0 -4px 30px rgba(255,0,204,0.2)",
           opacity: isPending ? 0.85 : 1,
-          transition: "opacity 0.15s",
+          transition: isDragging ? "opacity 0.15s" : "opacity 0.15s, transform 0.3s ease-out",
+          transform: isDragging
+            ? `translateY(${dragOffset}px)`
+            : visible
+              ? "translateY(0)"
+              : "translateY(100%)",
         }}
       >
         {/* Handle */}

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -332,3 +332,48 @@ describe("TaskDetail 閉じる動作", () => {
     vi.useRealTimers()
   })
 })
+
+describe("TaskDetail スワイプ動作", () => {
+  it("マウント時に body.style.overflow が hidden になる", () => {
+    document.body.style.overflow = ""
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    expect(document.body.style.overflow).toBe("hidden")
+  })
+
+  it("アンマウント時に body.style.overflow が元に戻る", () => {
+    document.body.style.overflow = "auto"
+    const { unmount } = render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    unmount()
+    expect(document.body.style.overflow).toBe("auto")
+  })
+
+  it("80px 以上スワイプで onClose が 280ms 後に呼ばれる", () => {
+    vi.useFakeTimers()
+    const onClose = vi.fn()
+    const { container } = render(<TaskDetail task={makeTask()} onClose={onClose} />)
+
+    const panel = container.querySelector(".rounded-t-2xl") as HTMLElement
+    act(() => {
+      fireEvent.touchStart(panel, { touches: [{ clientY: 0 }] })
+      fireEvent.touchMove(panel, { touches: [{ clientY: 90 }] })
+      fireEvent.touchEnd(panel, { changedTouches: [{ clientY: 90 }] })
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+    act(() => { vi.advanceTimersByTime(280) })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+
+  it("80px 未満スワイプでは onClose は呼ばれない", () => {
+    const onClose = vi.fn()
+    const { container } = render(<TaskDetail task={makeTask()} onClose={onClose} />)
+
+    const panel = container.querySelector(".rounded-t-2xl") as HTMLElement
+    fireEvent.touchStart(panel, { touches: [{ clientY: 0 }] })
+    fireEvent.touchMove(panel, { touches: [{ clientY: 50 }] })
+    fireEvent.touchEnd(panel, { changedTouches: [{ clientY: 50 }] })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 問題

タスク詳細を展開した後、下にスワイプするとパネルが閉じず、タスクリストがスクロールしてしまう。

## 原因

- パネル（`overflow-y-auto`）のスワイプがスクロールとして吸収される
- タッチイベントが背景の `<main>` まで伝播してタスクリストもスクロール

## 修正内容（`src/components/TaskDetail.tsx`）

- **スワイプダウンで閉じる**: `passive: false` の `touchmove` リスナーで、`scrollTop === 0` かつ下スワイプ時にスクロールを抑制してパネルをドラッグ追従させ、80px 以上でクローズ・未満はスナップバック
- **背景スクロール抑制**: mount 時に `document.body.style.overflow = 'hidden'`、unmount 時に元に戻す
- `textarea` 編集中はスワイプ閉じを無効化

## テスト

- ✅ ユニットテスト 108 件パス
- ✅ TypeScript エラーなし