### PR TITLE
fix: コメント投稿エラーログ・URL リンク化・SW 初回リロード修正

### DIFF
--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -6,6 +6,9 @@ export default function ServiceWorkerRegistration() {
   useEffect(() => {
     if (!("serviceWorker" in navigator)) return
 
+    // 初回インストール時は controllerchange でリロードしない（既存コントローラーがある時のみ更新リロード）
+    const hadController = !!navigator.serviceWorker.controller
+
     navigator.serviceWorker
       .register("/sw.js", { scope: "/", updateViaCache: "none" })
       .then((registration) => {
@@ -17,9 +20,9 @@ export default function ServiceWorkerRegistration() {
       })
       .catch(() => {})
 
-    // 新しい SW が制御を引き継いだらページをリロード
+    // 新しい SW が制御を引き継いだらページをリロード（初回インストール除く）
     navigator.serviceWorker.addEventListener("controllerchange", () => {
-      window.location.reload()
+      if (hadController) window.location.reload()
     })
   }, [])
   return null

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -545,6 +545,25 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
   )
 }
 
+function renderWithLinks(text: string): React.ReactNode {
+  const urlRegex = /https?:\/\/[^\s<>"']+/g
+  const parts: React.ReactNode[] = []
+  let last = 0
+  let match: RegExpExecArray | null
+  while ((match = urlRegex.exec(text)) !== null) {
+    if (match.index > last) parts.push(text.slice(last, match.index))
+    parts.push(
+      <a key={match.index} href={match[0]} target="_blank" rel="noopener noreferrer"
+         className="text-[#ff00cc] underline break-all">
+        {match[0]}
+      </a>
+    )
+    last = match.index + match[0].length
+  }
+  if (last < text.length) parts.push(text.slice(last))
+  return parts.length === 0 ? text : parts
+}
+
 function MarkdownPreview({ content }: { content: string }) {
   const lines = content.split("\n")
   let inCode = false
@@ -582,38 +601,38 @@ function MarkdownPreview({ content }: { content: string }) {
     if (line === "---") {
       elements.push(<hr key={i} className="my-2 border-[rgba(255,0,204,0.2)]" />)
     } else if (line.startsWith("# ")) {
-      elements.push(<p key={i} className="text-[#ffbbee] text-base font-bold mt-2 mb-0.5">{line.slice(2)}</p>)
+      elements.push(<p key={i} className="text-[#ffbbee] text-base font-bold mt-2 mb-0.5">{renderWithLinks(line.slice(2))}</p>)
     } else if (line.startsWith("## ")) {
-      elements.push(<p key={i} className="text-[#ffbbee] text-sm font-semibold mt-1.5 mb-0.5">{line.slice(3)}</p>)
+      elements.push(<p key={i} className="text-[#ffbbee] text-sm font-semibold mt-1.5 mb-0.5">{renderWithLinks(line.slice(3))}</p>)
     } else if (line.startsWith("### ")) {
-      elements.push(<p key={i} className="text-[#cc99bb] text-sm font-medium mt-1 mb-0.5">{line.slice(4)}</p>)
+      elements.push(<p key={i} className="text-[#cc99bb] text-sm font-medium mt-1 mb-0.5">{renderWithLinks(line.slice(4))}</p>)
     } else if (/^- \[x\] /i.test(line)) {
       elements.push(
         <p key={i} className="text-[#996688] text-sm line-through">
-          <span className="mr-1.5 not-italic">☑</span>{line.slice(6)}
+          <span className="mr-1.5 not-italic">☑</span>{renderWithLinks(line.slice(6))}
         </p>
       )
     } else if (/^- \[ \] /.test(line)) {
       elements.push(
         <p key={i} className="text-[#cc99bb] text-sm">
-          <span className="mr-1.5">☐</span>{line.slice(6)}
+          <span className="mr-1.5">☐</span>{renderWithLinks(line.slice(6))}
         </p>
       )
     } else if (line.startsWith("- ") || line.startsWith("* ")) {
-      elements.push(<p key={i} className="text-[#cc99bb] text-sm"><span className="mr-1.5 text-[#ff00cc]">・</span>{line.slice(2)}</p>)
+      elements.push(<p key={i} className="text-[#cc99bb] text-sm"><span className="mr-1.5 text-[#ff00cc]">・</span>{renderWithLinks(line.slice(2))}</p>)
     } else if (/^\d+\. /.test(line)) {
       const match = line.match(/^(\d+)\. (.*)/)
-      elements.push(<p key={i} className="text-[#cc99bb] text-sm"><span className="mr-1.5 text-[#ff00cc]">{match?.[1]}.</span>{match?.[2]}</p>)
+      elements.push(<p key={i} className="text-[#cc99bb] text-sm"><span className="mr-1.5 text-[#ff00cc]">{match?.[1]}.</span>{renderWithLinks(match?.[2] ?? "")}</p>)
     } else if (line.startsWith("> ")) {
       elements.push(
         <p key={i} className="text-[#996688] text-sm pl-3 italic" style={{ borderLeft: "2px solid rgba(255,0,204,0.4)" }}>
-          {line.slice(2)}
+          {renderWithLinks(line.slice(2))}
         </p>
       )
     } else if (line === "") {
       elements.push(<div key={i} className="h-2" />)
     } else {
-      elements.push(<p key={i} className="text-[#cc99bb] text-sm">{line}</p>)
+      elements.push(<p key={i} className="text-[#cc99bb] text-sm">{renderWithLinks(line)}</p>)
     }
   })
 

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -192,8 +192,8 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
       const newComment = await createTaskCommentAction(task.id, text)
       setComments((prev) => [...prev, newComment])
       setCommentInput("")
-    } catch {
-      setCommentPostError("コメントの投稿に失敗しました。")
+    } catch (e) {
+      setCommentPostError(e instanceof Error ? e.message : "コメントの投稿に失敗しました。")
     } finally {
       setIsPostingComment(false)
     }

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -242,6 +242,16 @@ describe("TaskDetail 本文編集", () => {
     expect(await screen.findByText("更新後の本文")).toBeInTheDocument()
   })
 
+  it("本文中の URL がクリッカブルリンクになる", async () => {
+    vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("詳細は https://example.com を参照")
+
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+
+    const link = await screen.findByRole("link", { name: "https://example.com" })
+    expect(link).toHaveAttribute("href", "https://example.com")
+    expect(link).toHaveAttribute("target", "_blank")
+  })
+
   it("本文取得に失敗してもローディングから復帰する", async () => {
     vi.mocked(getTaskBlocksAction).mockRejectedValueOnce(new Error("load failed"))
 

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -350,16 +350,21 @@ export async function getTaskComments(id: string): Promise<TaskComment[]> {
 
 export async function createTaskComment(id: string, text: string, author = "Unknown"): Promise<TaskComment> {
   if (isDevMode()) return addMockTaskComment(id, text)
-  const response = await notion.comments.create({
-    parent: { page_id: id },
-    rich_text: [{ type: "text", text: { content: text } }],
-  })
-  const c = response as CommentObjectResponse
-  return {
-    id: c.id,
-    text: c.rich_text.map((r) => r.plain_text).join(""),
-    author,
-    createdTime: c.created_time,
+  try {
+    const response = await notion.comments.create({
+      parent: { page_id: id },
+      rich_text: [{ type: "text", text: { content: text } }],
+    })
+    const c = response as CommentObjectResponse
+    return {
+      id: c.id,
+      text: c.rich_text.map((r) => r.plain_text).join(""),
+      author,
+      createdTime: c.created_time,
+    }
+  } catch (e) {
+    console.error("[createTaskComment] Notion error:", e)
+    throw e
   }
 }
 


### PR DESCRIPTION
## Summary

- コメント投稿失敗時のエラー詳細をログ出力・表示
- タスク本文内の URL をタップ可能なリンクに変換（`renderWithLinks()`）
- Service Worker 初回インストール時の不要なページリロードを修正（Playwright テストのハング原因だった）

## Test plan

- [x] `npm run test:unit` — 113 tests passed
- [x] `npx playwright test` — 22 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)