### PR TITLE
fix: SW controllerchange リスナークリーンアップ・URL末尾句読点除外

### DIFF
--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -21,9 +21,9 @@ export default function ServiceWorkerRegistration() {
       .catch(() => {})
 
     // 新しい SW が制御を引き継いだらページをリロード（初回インストール除く）
-    navigator.serviceWorker.addEventListener("controllerchange", () => {
-      if (hadController) window.location.reload()
-    })
+    const onControllerChange = () => { if (hadController) window.location.reload() }
+    navigator.serviceWorker.addEventListener("controllerchange", onControllerChange)
+    return () => navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange)
   }, [])
   return null
 }

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -552,13 +552,16 @@ function renderWithLinks(text: string): React.ReactNode {
   let match: RegExpExecArray | null
   while ((match = urlRegex.exec(text)) !== null) {
     if (match.index > last) parts.push(text.slice(last, match.index))
+    const rawUrl = match[0]
+    const url = rawUrl.replace(/[.,;:!?)\]'"]+$/, "")
     parts.push(
-      <a key={match.index} href={match[0]} target="_blank" rel="noopener noreferrer"
+      <a key={match.index} href={url} target="_blank" rel="noopener noreferrer"
          className="text-[#ff00cc] underline break-all">
-        {match[0]}
+        {url}
       </a>
     )
-    last = match.index + match[0].length
+    if (url.length < rawUrl.length) parts.push(rawUrl.slice(url.length))
+    last = match.index + rawUrl.length
   }
   if (last < text.length) parts.push(text.slice(last))
   return parts.length === 0 ? text : parts


### PR DESCRIPTION
## Summary

- `ServiceWorkerRegistration`: `controllerchange` リスナーを `removeEventListener` で解除するよう修正（再マウント時のメモリリーク防止）
- `renderWithLinks`: URL 末尾の句読点（`.,;:!?)` など）をリンク対象から除外し、プレーンテキストとして戻す

## Test plan

- [x] `npm run test:unit` — 113 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)