### PR TITLE
fix: URL末尾の日本語句読点がリンクに含まれる問題を修正

### DIFF
--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -553,7 +553,7 @@ function renderWithLinks(text: string): React.ReactNode {
   while ((match = urlRegex.exec(text)) !== null) {
     if (match.index > last) parts.push(text.slice(last, match.index))
     const rawUrl = match[0]
-    const url = rawUrl.replace(/[.,;:!?)\]'"]+$/, "")
+    const url = rawUrl.replace(/[.,;:!?)\]'"。、！？」』）〉》]+$/, "")
     parts.push(
       <a key={match.index} href={url} target="_blank" rel="noopener noreferrer"
          className="text-[#ff00cc] underline break-all">

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -252,6 +252,23 @@ describe("TaskDetail 本文編集", () => {
     expect(link).toHaveAttribute("target", "_blank")
   })
 
+  it.each([
+    ["句点（。）", "詳細は https://example.com。"],
+    ["読点（、）", "詳細は https://example.com、 次の手順へ"],
+    ["全角感嘆符（！）", "見てください https://example.com！"],
+    ["全角疑問符（？）", "これは https://example.com？"],
+    ["全角閉じ括弧（）", "（参考: https://example.com）"],
+    ["全角閉じ鉤括弧（」）", "「参照 https://example.com」"],
+    ["ASCII ピリオド", "詳細は https://example.com. を参照"],
+  ])("URL 末尾の %s が URL に含まれない", async (_, bodyText) => {
+    vi.mocked(getTaskBlocksAction).mockResolvedValueOnce(bodyText)
+
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+
+    const link = await screen.findByRole("link", { name: "https://example.com" })
+    expect(link).toHaveAttribute("href", "https://example.com")
+  })
+
   it("本文取得に失敗してもローディングから復帰する", async () => {
     vi.mocked(getTaskBlocksAction).mockRejectedValueOnce(new Error("load failed"))
 


### PR DESCRIPTION
## Summary

- `renderWithLinks` の末尾トリム正規表現に日本語句読点（`。、！？」』）〉》`）を追加
- `。、！？」）` など7パターンのユニットテストケースを追加

## Test plan

- [x] `npm run test:unit` — 120件全パス
- [x] `npx playwright test` — 22件パス（4件は環境依存のスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)