### PR TITLE
fix: URL末尾のパーセントエンコード済み全角句読点がリンクに含まれる問題を修正

### DIFF
--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -553,7 +553,14 @@ function renderWithLinks(text: string): React.ReactNode {
   while ((match = urlRegex.exec(text)) !== null) {
     if (match.index > last) parts.push(text.slice(last, match.index))
     const rawUrl = match[0]
-    const url = rawUrl.replace(/[.,;:!?)\]'"。、！？」』）〉》]+$/, "")
+    let url = rawUrl.replace(/[.,;:!?)\]'"。、！？」』）〉》]+$/, "")
+    url = url.replace(/((?:%[0-9A-Fa-f]{2})+)$/, (encoded) => {
+      try {
+        const decoded = decodeURIComponent(encoded)
+        if (/^[　-〿＀-￯]/.test(decoded)) return ""
+      } catch {}
+      return encoded
+    })
     parts.push(
       <a key={match.index} href={url} target="_blank" rel="noopener noreferrer"
          className="text-[#ff00cc] underline break-all">

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -553,7 +553,7 @@ function renderWithLinks(text: string): React.ReactNode {
   while ((match = urlRegex.exec(text)) !== null) {
     if (match.index > last) parts.push(text.slice(last, match.index))
     const rawUrl = match[0]
-    const url = rawUrl.replace(/[.,;:!?)\]'"]+$/, "")
+    const url = rawUrl.replace(/[.,;:!?)\]'"。、！？」』）〉》]+$/, "")
     parts.push(
       <a key={match.index} href={url} target="_blank" rel="noopener noreferrer"
          className="text-[#ff00cc] underline break-all">

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -260,6 +260,7 @@ describe("TaskDetail 本文編集", () => {
     ["全角閉じ括弧（）", "（参考: https://example.com）"],
     ["全角閉じ鉤括弧（」）", "「参照 https://example.com」"],
     ["ASCII ピリオド", "詳細は https://example.com. を参照"],
+    ["全角閉じ括弧のパーセントエンコード", "詳細は https://example.com%EF%BC%89%E3%81%A7%E4%BA%8B%E6%A1%88%E3%81%AE%E8%A9%B3%E7%B4%B0%E3%82%92%E7%A2%BA%E8%AA%8D"],
   ])("URL 末尾の %s が URL に含まれない", async (_, bodyText) => {
     vi.mocked(getTaskBlocksAction).mockResolvedValueOnce(bodyText)
 

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -252,6 +252,23 @@ describe("TaskDetail 本文編集", () => {
     expect(link).toHaveAttribute("target", "_blank")
   })
 
+  it.each([
+    ["句点（。）", "詳細は https://example.com。"],
+    ["読点（、）", "詳細は https://example.com、 次の手順へ"],
+    ["全角感嘆符（！）", "見てください https://example.com！"],
+    ["全角疑問符（？）", "これは https://example.com？"],
+    ["全角閉じ括弧（）", "（参考: https://example.com）"],
+    ["全角閉じ鉤括弧（」）", "「参照 https://example.com」"],
+    ["ASCII ピリオド", "詳細は https://example.com. を参照"],
+  ])("URL 末尾の %s が URL に含まれない", async (_, bodyText) => {
+    vi.mocked(getTaskBlocksAction).mockResolvedValueOnce(bodyText)
+
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+
+    const link = await screen.findByRole("link", { name: "https://example.com" })
+    expect(link).toHaveAttribute("href", "https://example.com")
+  })
+
   it("本文取得に失敗してもローディングから復帰する", async () => {
     vi.mocked(getTaskBlocksAction).mockRejectedValueOnce(new Error("load failed"))
 


### PR DESCRIPTION
## Summary

- `renderWithLinks` でパーセントエンコードされた全角句読点（例: `%EF%BC%89` = `）`）が URL の末尾に含まれてしまう問題を修正
- デコードした先頭文字が CJK 記号・句読点（U+3000–U+303F）または全角形（U+FF00–U+FFEF）の場合、末尾のパーセントエンコードシーケンスを除去するロジックを追加
- 正規の日本語 Wikipedia URL（`/wiki/%E6%97%A5%E6%9C%AC%E8%AA%9E` など）は影響を受けない

## Test plan

- [x] `npm run test:unit` — 121 tests passed
- [x] `npx playwright test` — 22 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)