### PR TITLE
fix: リテラル日本語句読点＋後続テキストがURLに含まれる問題を修正

### DIFF
--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -554,6 +554,7 @@ function renderWithLinks(text: string): React.ReactNode {
     if (match.index > last) parts.push(text.slice(last, match.index))
     const rawUrl = match[0]
     let url = rawUrl.replace(/[.,;:!?)\]'"。、！？」』）〉》]+$/, "")
+    url = url.replace(/[　-〿＀-￯][　-〿぀-ヿ一-鿿豈-﫿＀-￯]*$/, "")
     url = url.replace(/((?:%[0-9A-Fa-f]{2})+)$/, (encoded) => {
       try {
         const decoded = decodeURIComponent(encoded)

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -261,6 +261,7 @@ describe("TaskDetail 本文編集", () => {
     ["全角閉じ鉤括弧（」）", "「参照 https://example.com」"],
     ["ASCII ピリオド", "詳細は https://example.com. を参照"],
     ["全角閉じ括弧のパーセントエンコード", "詳細は https://example.com%EF%BC%89%E3%81%A7%E4%BA%8B%E6%A1%88%E3%81%AE%E8%A9%B3%E7%B4%B0%E3%82%92%E7%A2%BA%E8%AA%8D"],
+    ["全角閉じ括弧＋日本語テキスト（リテラル）", "詳細は https://example.com）で事案の詳細と対応を確認"],
   ])("URL 末尾の %s が URL に含まれない", async (_, bodyText) => {
     vi.mocked(getTaskBlocksAction).mockResolvedValueOnce(bodyText)
 


### PR DESCRIPTION
## Summary

- Notion の `plain_text` はリテラルの日本語文字で返るため、`）で事案の詳細と対応を確認` のような文字列が URL に含まれてしまう問題を修正
- 正規表現でリテラルの CJK 句読点（U+3000–U+303F, U+FF00–U+FFEF）で始まり、後続する CJK 文字（ひらがな・カタカナ・漢字）を末尾から除去する処理を追加
- `https://ja.wikipedia.org/wiki/日本語` のような正規の日本語 URL（`日`=U+4E00 は CJK 句読点ではない）は影響を受けない

## Test plan

- [x] `npm run test:unit` — 122 tests passed
- [x] `npx playwright test` — 22 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)