### PR TITLE
feat: ?task=<pageId> でタスクを直接開けるURLを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,9 +5,15 @@ import { TaskManager } from "@/components/TaskManager"
 import { HydrationCheck } from "@/components/HydrationCheck"
 import { getQueryStatuses } from "@/constants/filters"
 
-export default async function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
   const cookieStore = await cookies()
   const filter = cookieStore.get("filter")?.value ?? "active"
+  const { task: taskParam } = await searchParams
+  const initialTaskId = typeof taskParam === "string" ? taskParam : null
 
   const [session, tasks] = await Promise.all([
     auth(),
@@ -36,7 +42,7 @@ export default async function Page() {
       </header>
 
       <HydrationCheck />
-      <TaskManager tasks={tasks} currentFilter={filter} />
+      <TaskManager tasks={tasks} currentFilter={filter} initialTaskId={initialTaskId} />
     </div>
   )
 }

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -9,10 +9,10 @@ import { setFilterAction, refreshTasksAction } from "@/app/actions"
 import { FILTERS } from "@/constants/filters"
 import { sortByPriorityAndDue, groupAndSort } from "@/lib/task-sort"
 
-export function TaskManager({ tasks, currentFilter }: { tasks: Task[]; currentFilter: string }) {
+export function TaskManager({ tasks, currentFilter, initialTaskId }: { tasks: Task[]; currentFilter: string; initialTaskId?: string | null }) {
   const [isPending, startTransition] = useTransition()
   const [filterKey, setFilterKey] = useState(currentFilter)
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(initialTaskId ?? null)
   const selectedTask = tasks.find((t) => t.id === selectedTaskId) ?? null
 
   const current = FILTERS.find((f) => f.key === filterKey) ?? FILTERS[0]


### PR DESCRIPTION
## Summary

- `page.tsx` で `searchParams.task` を読み取り `initialTaskId` として `TaskManager` へ渡す
- `TaskManager` が `initialTaskId` で `selectedTaskId` を初期化し、ページロード時に該当タスクの詳細を表示
- URL 例: `https://todo.eh6gac4.work/?task=<notionPageId>`

## Test plan

- [ ] ユニットテスト 122件パス
- [ ] Playwright E2E 22件パス（既存テストが全てグリーン）

🤖 Generated with [Claude Code](https://claude.com/claude-code)