### PR TITLE
feat: タスク一覧をスワイプでカルーセル風にフィルター切り替え

### DIFF
--- a/e2e/tap.spec.ts
+++ b/e2e/tap.spec.ts
@@ -81,4 +81,67 @@ test.describe("タップ応答調査", () => {
       console.log(`  → FABとタスクが重なっている: ${overlap}`)
     }
   })
+
+  // WebKit / Chromium 共通: touches プロパティを手動付与した Event でスワイプをシミュレート
+  async function dispatchSwipe(page: import("@playwright/test").Page, selector: string, dx: number, dy = 0) {
+    const box = await page.locator(selector).boundingBox()
+    if (!box) return
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    await page.evaluate(([sel, startX, startY, deltaX, deltaY]) => {
+      const el = document.querySelector(sel as string)!
+      function makeTouch(x: number, y: number) {
+        return { clientX: x, clientY: y, identifier: 1, target: el }
+      }
+      function fire(type: string, touches: object[], changed = touches) {
+        const e = new Event(type, { bubbles: true, cancelable: true })
+        Object.defineProperty(e, "touches",        { value: touches })
+        Object.defineProperty(e, "targetTouches",  { value: touches })
+        Object.defineProperty(e, "changedTouches", { value: changed })
+        el.dispatchEvent(e)
+      }
+      fire("touchstart", [makeTouch(startX as number, startY as number)])
+      fire("touchmove",  [makeTouch((startX as number) + (deltaX as number) / 2, (startY as number) + (deltaY as number) / 2)])
+      fire("touchmove",  [makeTouch((startX as number) + (deltaX as number), (startY as number) + (deltaY as number))])
+      fire("touchend",   [], [makeTouch((startX as number) + (deltaX as number), (startY as number) + (deltaY as number))])
+    }, [selector, cx, cy, dx, dy])
+  }
+
+  test("左スワイプでフィルターが次に進む (active → todo)", async ({ page }) => {
+    const filterSelect = page.locator("[data-testid='filter-select']")
+    expect(await filterSelect.inputValue()).toBe("active")
+
+    await dispatchSwipe(page, "[data-testid='task-list-main']", -80)
+    await expect(filterSelect).toHaveValue("todo", { timeout: 5_000 })
+  })
+
+  test("右スワイプでフィルターが前に戻る (todo → active)", async ({ page }) => {
+    const filterSelect = page.locator("[data-testid='filter-select']")
+    await filterSelect.selectOption("todo")
+    // スケルトン（ul li のみ）ではなくリアルタスク（ul li p）が表示されるまで待つ
+    // これにより isPending=false（startTransition 完了）を確認できる
+    await page.locator("ul.divide-y li p").first().waitFor({ state: "visible", timeout: 10_000 })
+
+    await dispatchSwipe(page, "[data-testid='task-list-main']", 80)
+    await expect(filterSelect).toHaveValue("active", { timeout: 5_000 })
+  })
+
+  test("縦スワイプではフィルターが変わらない", async ({ page }) => {
+    const filterSelect = page.locator("[data-testid='filter-select']")
+    const before = await filterSelect.inputValue()
+
+    await dispatchSwipe(page, "[data-testid='task-list-main']", 20, 200)
+    await page.waitForTimeout(400)
+    expect(await filterSelect.inputValue()).toBe(before)
+  })
+
+  test("ページネーションドットが 6 個表示され、クリックでフィルターが変わる", async ({ page }) => {
+    const dots = page.locator('[role="tab"]')
+    await expect(dots).toHaveCount(6)
+
+    const allDot = page.locator('[role="tab"][aria-label="すべて"]')
+    await allDot.click()
+    const filterSelect = page.locator("[data-testid='filter-select']")
+    await expect(filterSelect).toHaveValue("all", { timeout: 5_000 })
+  })
 })

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useTransition } from "react"
+import { useState, useTransition, useEffect, useRef } from "react"
 import type { Task } from "@/types/task"
 import { TaskItem } from "./TaskItem"
 import { TaskDetail } from "./TaskDetail"
@@ -24,6 +24,131 @@ export function TaskManager({ tasks, currentFilter, initialTaskId }: { tasks: Ta
   const groups = isGrouped ? groupAndSort(filtered) : null
   const sortedFlat = !isGrouped ? sortByPriorityAndDue(filtered) : null
 
+  // ─── Carousel refs ────────────────────────────────────────────────────────
+  const mainRef = useRef<HTMLElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const rafRef = useRef(0)
+  const isAnimatingRef = useRef(false)
+
+  // stale closure 対策
+  const filterKeyRef = useRef(filterKey)
+  const selectedTaskIdRef = useRef<string | null>(selectedTaskId)
+  const isPendingRef = useRef(false)
+
+  useEffect(() => { filterKeyRef.current = filterKey }, [filterKey])
+  useEffect(() => { selectedTaskIdRef.current = selectedTaskId }, [selectedTaskId])
+  useEffect(() => { isPendingRef.current = isPending }, [isPending])
+
+  // ─── Swipe gesture ────────────────────────────────────────────────────────
+  useEffect(() => {
+    const el = mainRef.current
+    if (!el) return
+    const THRESHOLD = 60
+    const LOCK_DIST = 8
+
+    const touchStartXRef = { current: 0 }
+    const touchStartYRef = { current: 0 }
+    const directionRef = { current: null as "horiz" | "vert" | null }
+
+    function onStart(e: TouchEvent) {
+      if (e.touches.length > 1) { directionRef.current = "vert"; return }
+      if (isAnimatingRef.current) return
+      touchStartXRef.current = e.touches[0].clientX
+      touchStartYRef.current = e.touches[0].clientY
+      directionRef.current = null
+    }
+
+    function onMove(e: TouchEvent) {
+      if (isAnimatingRef.current) return
+      const dx = e.touches[0].clientX - touchStartXRef.current
+      const dy = e.touches[0].clientY - touchStartYRef.current
+
+      if (directionRef.current === null) {
+        if (Math.hypot(dx, dy) < LOCK_DIST) return
+        directionRef.current = Math.abs(dx) > Math.abs(dy) ? "horiz" : "vert"
+      }
+      if (directionRef.current !== "horiz") return
+
+      e.preventDefault()
+
+      cancelAnimationFrame(rafRef.current)
+      const capture = dx
+      rafRef.current = requestAnimationFrame(() => {
+        if (contentRef.current) {
+          contentRef.current.style.transition = "none"
+          contentRef.current.style.transform = `translateX(${capture}px)`
+        }
+      })
+    }
+
+    function onEnd(e: TouchEvent) {
+      cancelAnimationFrame(rafRef.current)
+      if (directionRef.current !== "horiz") return
+      if (selectedTaskIdRef.current !== null) return
+      if (isPendingRef.current) return
+      if (isAnimatingRef.current) return
+
+      const dx = e.changedTouches[0].clientX - touchStartXRef.current
+
+      if (Math.abs(dx) < THRESHOLD) {
+        snapBack()
+        return
+      }
+
+      const idx = FILTERS.findIndex((f) => f.key === filterKeyRef.current)
+      const cur = idx < 0 ? 0 : idx
+      const nextFilter = dx < 0
+        ? FILTERS[(cur + 1) % FILTERS.length]
+        : FILTERS[(cur - 1 + FILTERS.length) % FILTERS.length]
+      const exitX = dx < 0 ? -window.innerWidth : window.innerWidth
+      const entryX = -exitX
+
+      commitSwipe(nextFilter.key, exitX, entryX)
+    }
+
+    function snapBack() {
+      if (!contentRef.current) return
+      contentRef.current.style.transition = "transform 200ms ease-out"
+      contentRef.current.style.transform = "translateX(0)"
+    }
+
+    function commitSwipe(nextKey: string, exitX: number, entryX: number) {
+      const content = contentRef.current
+      if (!content) return
+      isAnimatingRef.current = true
+
+      content.style.transition = "transform 150ms ease-in"
+      content.style.transform = `translateX(${exitX}px)`
+
+      setTimeout(() => {
+        setFilterKey(nextKey)
+        startTransition(async () => { await setFilterAction(nextKey) })
+
+        requestAnimationFrame(() => {
+          if (!contentRef.current) return
+          contentRef.current.style.transition = "none"
+          contentRef.current.style.transform = `translateX(${entryX}px)`
+          requestAnimationFrame(() => {
+            if (!contentRef.current) return
+            contentRef.current.style.transition = "transform 150ms ease-out"
+            contentRef.current.style.transform = "translateX(0)"
+            setTimeout(() => { isAnimatingRef.current = false }, 150)
+          })
+        })
+      }, 150)
+    }
+
+    el.addEventListener("touchstart", onStart, { passive: true })
+    el.addEventListener("touchmove", onMove, { passive: false })
+    el.addEventListener("touchend", onEnd, { passive: true })
+    return () => {
+      cancelAnimationFrame(rafRef.current)
+      el.removeEventListener("touchstart", onStart)
+      el.removeEventListener("touchmove", onMove)
+      el.removeEventListener("touchend", onEnd)
+    }
+  }, [])
+
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
       {/* ローディングバー */}
@@ -36,50 +161,85 @@ export function TaskManager({ tasks, currentFilter, initialTaskId }: { tasks: Ta
         }}
       />
 
-      <div className="bg-[#0d0014] border-b border-[rgba(255,0,204,0.3)] px-4 py-2.5 flex-shrink-0 flex gap-2">
-        <select
-          data-testid="filter-select"
-          value={filterKey}
-          onChange={(e) => {
-            const next = e.target.value
-            setFilterKey(next)
-            startTransition(async () => { await setFilterAction(next) })
-          }}
-          className="w-full rounded-xl px-4 py-3 text-sm bg-[#160022] text-[#ffbbee] border border-[rgba(255,0,204,0.3)] focus:outline-none focus:border-[#ff00cc]"
-          style={{ transition: "border-color 0.2s" }}
-        >
-          {FILTERS.map((f) => (
-            <option key={f.key} value={f.key}>{f.label}</option>
-          ))}
-        </select>
-        <button
-          data-testid="refresh-button"
-          disabled={isPending}
-          onClick={() => startTransition(async () => { await refreshTasksAction() })}
-          className="flex-shrink-0 w-10 self-stretch rounded-xl border border-[rgba(255,0,204,0.3)] bg-[#160022] text-[#ff00cc] flex items-center justify-center hover:border-[#ff00cc] disabled:opacity-40 transition-colors"
-        >
-          <svg
-            className={isPending ? "animate-spin" : ""}
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+      <div className="bg-[#0d0014] border-b border-[rgba(255,0,204,0.3)] px-4 pt-2.5 pb-2 flex-shrink-0 flex flex-col gap-1.5">
+        <div className="flex gap-2">
+          <select
+            data-testid="filter-select"
+            value={filterKey}
+            onChange={(e) => {
+              const next = e.target.value
+              setFilterKey(next)
+              startTransition(async () => { await setFilterAction(next) })
+            }}
+            className="w-full rounded-xl px-4 py-3 text-sm bg-[#160022] text-[#ffbbee] border border-[rgba(255,0,204,0.3)] focus:outline-none focus:border-[#ff00cc]"
+            style={{ transition: "border-color 0.2s" }}
           >
-            <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
-            <path d="M21 3v5h-5" />
-            <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
-            <path d="M8 16H3v5" />
-          </svg>
-        </button>
+            {FILTERS.map((f) => (
+              <option key={f.key} value={f.key}>{f.label}</option>
+            ))}
+          </select>
+          <button
+            data-testid="refresh-button"
+            disabled={isPending}
+            onClick={() => startTransition(async () => { await refreshTasksAction() })}
+            className="flex-shrink-0 w-10 self-stretch rounded-xl border border-[rgba(255,0,204,0.3)] bg-[#160022] text-[#ff00cc] flex items-center justify-center hover:border-[#ff00cc] disabled:opacity-40 transition-colors"
+          >
+            <svg
+              className={isPending ? "animate-spin" : ""}
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+              <path d="M21 3v5h-5" />
+              <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+              <path d="M8 16H3v5" />
+            </svg>
+          </button>
+        </div>
+
+        {/* ページネーションドット */}
+        <div className="flex justify-center items-center gap-1.5 pb-0.5">
+          {FILTERS.map((f) => {
+            const active = f.key === filterKey
+            return (
+              <button
+                key={f.key}
+                role="tab"
+                aria-selected={active}
+                aria-label={f.label}
+                onClick={() => {
+                  if (isAnimatingRef.current) return
+                  setFilterKey(f.key)
+                  startTransition(async () => { await setFilterAction(f.key) })
+                }}
+                className="transition-all duration-200"
+                style={{
+                  width: active ? "20px" : "6px",
+                  height: "6px",
+                  borderRadius: "3px",
+                  backgroundColor: active ? "#ff00cc" : "rgba(153,102,136,0.4)",
+                  boxShadow: active ? "0 0 6px rgba(255,0,204,0.7)" : "none",
+                }}
+              />
+            )
+          })}
+        </div>
       </div>
 
-      <main className="flex-1 overflow-y-auto">
-        <div className="max-w-2xl mx-auto">
+      <main
+        ref={mainRef}
+        data-testid="task-list-main"
+        className="flex-1 overflow-y-auto"
+        style={{ overflowX: "hidden" }}
+      >
+        <div ref={contentRef} className="max-w-2xl mx-auto" style={{ willChange: "transform" }}>
           {isPending ? (
             <ul className="divide-y divide-[rgba(255,0,204,0.1)]">
               {[...Array(5)].map((_, i) => (

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
 import { TaskManager } from "@/components/TaskManager"
+import { FILTERS } from "@/constants/filters"
 import type { Task } from "@/types/task"
 
 vi.mock("@/app/actions", () => ({
   setFilterAction: vi.fn().mockResolvedValue(undefined),
+  refreshTasksAction: vi.fn().mockResolvedValue(undefined),
 }))
 
 // TaskItem / TaskCreate は描画内容ではなくフィルター論理をテストするため簡略化
@@ -19,6 +21,15 @@ vi.mock("@/components/TaskItem", () => ({
 vi.mock("@/components/TaskCreate", () => ({
   TaskCreate: () => null,
 }))
+
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 0 })
+  vi.stubGlobal("cancelAnimationFrame", () => {})
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 function makeTask(overrides: Partial<Task>): Task {
   return {
@@ -112,5 +123,101 @@ describe("TaskManager フィルター", () => {
     const nullStatusTasks = [makeTask({ id: "n1", title: "ステータス不明", status: null })]
     render(<TaskManager tasks={nullStatusTasks} currentFilter="active" />)
     expect(screen.queryByText("ステータス不明")).not.toBeInTheDocument()
+  })
+})
+
+// ─── スワイプテスト用ヘルパー ─────────────────────────────────────────────
+
+function swipe(el: HTMLElement, dx: number, dy = 0) {
+  fireEvent.touchStart(el, { touches: [{ clientX: 0, clientY: 0 }] })
+  fireEvent.touchMove(el, { touches: [{ clientX: dx / 2, clientY: dy / 2 }] })
+  fireEvent.touchEnd(el, { changedTouches: [{ clientX: dx, clientY: dy }] })
+}
+
+function getMain() {
+  return document.querySelector("[data-testid='task-list-main']") as HTMLElement
+}
+
+describe("スワイプフィルター切り替え", () => {
+  // commitSwipe 内の setTimeout(150) を制御するため fake timers を使用
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["setTimeout"] })
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("左スワイプ 80px で active(0番) → todo(1番) に変わる", async () => {
+    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    act(() => { swipe(getMain(), -80) })
+    await act(async () => { vi.runAllTimers() })
+    expect(screen.getByText("未着手タスク")).toBeInTheDocument()
+    expect(screen.queryByText("進行中タスク")).not.toBeInTheDocument()
+  })
+
+  it("右スワイプ 80px で todo(1番) → active(0番) に戻る", async () => {
+    render(<TaskManager tasks={tasks} currentFilter="todo" />)
+    act(() => { swipe(getMain(), 80) })
+    await act(async () => { vi.runAllTimers() })
+    expect(screen.getByText("未着手タスク")).toBeInTheDocument()
+    expect(screen.getByText("進行中タスク")).toBeInTheDocument()
+  })
+
+  it("左スワイプ @ all(末尾) → active(先頭) に循環する", async () => {
+    render(<TaskManager tasks={tasks} currentFilter="all" />)
+    act(() => { swipe(getMain(), -80) })
+    await act(async () => { vi.runAllTimers() })
+    // active: 未着手・進行中のみ
+    expect(screen.getByText("未着手タスク")).toBeInTheDocument()
+    expect(screen.queryByText("確認中タスク")).not.toBeInTheDocument()
+  })
+
+  it("右スワイプ @ active(先頭) → all(末尾) に循環する", async () => {
+    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    act(() => { swipe(getMain(), 80) })
+    await act(async () => { vi.runAllTimers() })
+    expect(screen.getAllByTestId("task-item")).toHaveLength(5)
+  })
+
+  it("50px スワイプ（閾値未満）ではフィルターが変わらない", async () => {
+    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    act(() => { swipe(getMain(), -50) })
+    await act(async () => { vi.runAllTimers() })
+    // active のまま: 進行中が表示される
+    expect(screen.getByText("進行中タスク")).toBeInTheDocument()
+    expect(screen.queryByText("確認中タスク")).not.toBeInTheDocument()
+  })
+
+  it("縦スワイプ (dx=30, dy=200) ではフィルターが変わらない", async () => {
+    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    act(() => { swipe(getMain(), 30, 200) })
+    await act(async () => { vi.runAllTimers() })
+    expect(screen.getByText("進行中タスク")).toBeInTheDocument()
+    expect(screen.queryByText("確認中タスク")).not.toBeInTheDocument()
+  })
+})
+
+describe("ページネーションドット", () => {
+  it("FILTERS の数だけドットが表示される", () => {
+    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    expect(screen.getAllByRole("tab")).toHaveLength(FILTERS.length)
+  })
+
+  it("現在フィルターのドットが aria-selected=true、他は false", () => {
+    render(<TaskManager tasks={tasks} currentFilter="review" />)
+    const dots = screen.getAllByRole("tab")
+    const activeIdx = FILTERS.findIndex((f) => f.key === "review")
+    dots.forEach((dot, i) => {
+      expect(dot.getAttribute("aria-selected")).toBe(i === activeIdx ? "true" : "false")
+    })
+  })
+
+  it("ドットをクリックするとフィルターが変わる", async () => {
+    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    const allDot = screen.getByRole("tab", { name: "すべて" })
+    await act(async () => { fireEvent.click(allDot) })
+    await waitFor(() => {
+      expect(screen.getAllByTestId("task-item")).toHaveLength(5)
+    })
   })
 })


### PR DESCRIPTION
## Summary

- 左右スワイプでフィルターをサイクル（6種類を循環）
- ドラッグ中はコンテンツが指に追従（rAF スロットリング）
- 閾値 60px 超えたら現コンテンツをスライドアウト → 新コンテンツがスライドイン（各 150ms）
- 閾値未満なら 200ms でスナップバック
- ページネーションドット（現在位置をピル形状で強調、タップでも切り替え可）
- ガード: `isPending` / `isAnimating` / `TaskDetail` 表示中はスワイプ無効

## Test plan

- [x] ユニットテスト 131件パス
- [x] Playwright E2E 全件パス（スワイプ左右・縦スワイプ無効・ドット動作 追加確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)