### PR TITLE
fix: ログイン直後のページ読み込みエラーを修正

### DIFF
--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { loginAction } from "./actions"
+
+type Props = {
+  callbackUrl?: string
+  initialError?: string
+  initialMins?: string
+  initialRemaining?: string
+}
+
+export function LoginForm({ callbackUrl, initialError, initialMins, initialRemaining }: Props) {
+  const [error, setError] = useState<string | undefined>(initialError)
+  const [remaining, setRemaining] = useState<number | undefined>(
+    initialRemaining ? Number(initialRemaining) : undefined
+  )
+  const [mins, setMins] = useState<number | undefined>(
+    initialMins ? Number(initialMins) : undefined
+  )
+  const [isPending, startTransition] = useTransition()
+
+  const isLocked = error === "locked"
+
+  function handleSubmit(formData: FormData) {
+    startTransition(async () => {
+      const result = await loginAction(formData)
+      if ("success" in result) {
+        window.location.href = callbackUrl ?? "/"
+      } else if (result.error === "locked") {
+        setError("locked")
+        setMins(result.mins)
+      } else {
+        setError("CredentialsSignin")
+        setRemaining(result.remaining)
+      }
+    })
+  }
+
+  return (
+    <form action={handleSubmit} className="space-y-5">
+      <div>
+        <label htmlFor="username" className="block text-xs text-[#996688] mb-2 tracking-widest uppercase">
+          ユーザー名
+        </label>
+        <input
+          id="username"
+          name="username"
+          type="text"
+          required
+          autoComplete="username"
+          className="w-full rounded-xl px-4 py-3 text-sm bg-[#0d0014] text-[#ffbbee] placeholder:text-[#553355] focus:outline-none"
+          style={{ border: "1px solid rgba(255,0,204,0.3)" }}
+        />
+      </div>
+      <div>
+        <label htmlFor="password" className="block text-xs text-[#996688] mb-2 tracking-widest uppercase">
+          パスワード
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          required
+          autoComplete="current-password"
+          className="w-full rounded-xl px-4 py-3 text-sm bg-[#0d0014] text-[#ffbbee] placeholder:text-[#553355] focus:outline-none"
+          style={{ border: "1px solid rgba(255,0,204,0.3)" }}
+        />
+      </div>
+
+      {error === "CredentialsSignin" && (
+        <>
+          <p className="text-xs text-[#ff3355]">認証に失敗しました</p>
+          {remaining !== undefined && (
+            <p className="text-xs text-[#996688]">あと{remaining}回でロックされます</p>
+          )}
+        </>
+      )}
+      {isLocked && (
+        <p className="text-xs text-[#ff3355]">
+          試行回数超過。約{mins ?? 30}分後に再試行してください。
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isLocked || isPending}
+        className="w-full rounded-xl py-3 text-sm tracking-widest uppercase disabled:opacity-40 transition-all mt-2"
+        style={{
+          backgroundColor: "#ff00cc",
+          color: "#0d0014",
+          boxShadow: "0 0 12px rgba(255,0,204,0.5), 0 0 30px rgba(255,0,204,0.2)",
+        }}
+      >
+        ACCESS
+      </button>
+    </form>
+  )
+}

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,0 +1,39 @@
+"use server"
+
+import { headers } from "next/headers"
+import { signIn } from "@/auth"
+import { AuthError } from "next-auth"
+import { checkRateLimit, recordFailure, recordSuccess } from "@/lib/rate-limit"
+
+export type LoginResult =
+  | { success: true }
+  | { error: "locked"; mins: number }
+  | { error: "CredentialsSignin"; remaining: number }
+
+export async function loginAction(formData: FormData): Promise<LoginResult> {
+  const hdrs = await headers()
+  const ip = hdrs.get("x-forwarded-for")?.split(",")[0].trim() ?? "unknown"
+
+  const limit = checkRateLimit(ip)
+  if (limit.blocked) {
+    const mins = Math.ceil((limit.unlocksAt!.getTime() - Date.now()) / 60000)
+    return { error: "locked", mins }
+  }
+
+  try {
+    await signIn("credentials", {
+      username: formData.get("username"),
+      password: formData.get("password"),
+      redirect: false,
+    })
+    recordSuccess(ip)
+    return { success: true }
+  } catch (e) {
+    if (e instanceof AuthError) {
+      const result = recordFailure(ip)
+      if (result.blocked) return { error: "locked", mins: 30 }
+      return { error: "CredentialsSignin", remaining: result.remaining }
+    }
+    throw e
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,6 @@
 import { redirect } from "next/navigation"
-import { headers } from "next/headers"
-import { signIn, auth } from "@/auth"
-import { AuthError } from "next-auth"
-import { checkRateLimit, recordFailure, recordSuccess } from "@/lib/rate-limit"
+import { auth } from "@/auth"
+import { LoginForm } from "./LoginForm"
 
 type SearchParams = {
   callbackUrl?: string
@@ -37,95 +35,12 @@ export default async function LoginPage({
         >
           ✦ SYSTEM LOGIN
         </h1>
-
-        <form
-          action={async (formData) => {
-            "use server"
-            const hdrs = await headers()
-            const ip = hdrs.get("x-forwarded-for")?.split(",")[0].trim() ?? "unknown"
-
-            const limit = checkRateLimit(ip)
-            if (limit.blocked) {
-              const mins = Math.ceil((limit.unlocksAt!.getTime() - Date.now()) / 60000)
-              redirect(`/login?error=locked&mins=${mins}${callbackUrl ? `&callbackUrl=${encodeURIComponent(callbackUrl)}` : ""}`)
-            }
-
-            try {
-              await signIn("credentials", {
-                username: formData.get("username"),
-                password: formData.get("password"),
-                redirectTo: callbackUrl ?? "/",
-              })
-              recordSuccess(ip)
-            } catch (e) {
-              if (e instanceof AuthError) {
-                const result = recordFailure(ip)
-                if (result.blocked) {
-                  redirect(`/login?error=locked&mins=30${callbackUrl ? `&callbackUrl=${encodeURIComponent(callbackUrl)}` : ""}`)
-                }
-                redirect(`/login?error=CredentialsSignin&remaining=${result.remaining}${callbackUrl ? `&callbackUrl=${encodeURIComponent(callbackUrl)}` : ""}`)
-              }
-              throw e
-            }
-          }}
-          className="space-y-5"
-        >
-          <div>
-            <label htmlFor="username" className="block text-xs text-[#996688] mb-2 tracking-widest uppercase">
-              ユーザー名
-            </label>
-            <input
-              id="username"
-              name="username"
-              type="text"
-              required
-              autoComplete="username"
-              className="w-full rounded-xl px-4 py-3 text-sm bg-[#0d0014] text-[#ffbbee] placeholder:text-[#553355] focus:outline-none"
-              style={{ border: "1px solid rgba(255,0,204,0.3)" }}
-            />
-          </div>
-          <div>
-            <label htmlFor="password" className="block text-xs text-[#996688] mb-2 tracking-widest uppercase">
-              パスワード
-            </label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              required
-              autoComplete="current-password"
-              className="w-full rounded-xl px-4 py-3 text-sm bg-[#0d0014] text-[#ffbbee] placeholder:text-[#553355] focus:outline-none"
-              style={{ border: "1px solid rgba(255,0,204,0.3)" }}
-            />
-          </div>
-
-          {error === "CredentialsSignin" && (
-            <>
-              <p className="text-xs text-[#ff3355]">認証に失敗しました</p>
-              {remaining && (
-                <p className="text-xs text-[#996688]">あと{remaining}回でロックされます</p>
-              )}
-            </>
-          )}
-          {error === "locked" && (
-            <p className="text-xs text-[#ff3355]">
-              試行回数超過。約{mins ?? 30}分後に再試行してください。
-            </p>
-          )}
-
-          <button
-            type="submit"
-            disabled={error === "locked"}
-            className="w-full rounded-xl py-3 text-sm tracking-widest uppercase disabled:opacity-40 transition-all mt-2"
-            style={{
-              backgroundColor: "#ff00cc",
-              color: "#0d0014",
-              boxShadow: "0 0 12px rgba(255,0,204,0.5), 0 0 30px rgba(255,0,204,0.2)",
-            }}
-          >
-            ACCESS
-          </button>
-        </form>
+        <LoginForm
+          callbackUrl={callbackUrl}
+          initialError={error}
+          initialMins={mins}
+          initialRemaining={remaining}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Next.js サーバーアクションの `NEXT_REDIRECT` はクライアントサイドナビゲーション（RSC fetch）として処理されるため、Cloudflare Workers 環境では Set-Cookie が RSC fetch より先に確定しないことがあった
- `signIn({ redirect: false })` でセッションクッキーだけ設定し、クライアントが `window.location.href` でフルページリロードを実行する方式に変更
- ログインフォームをクライアントコンポーネント（`LoginForm.tsx`）として切り出し、サーバーアクション（`actions.ts`）はリダイレクトなしで成功/エラーを返す設計に

## Test plan

- [x] `npm run test:unit` 131テスト通過
- [x] `npx playwright test` 28テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)