### PR TITLE
feat: タスク追加時に本文（body）を登録できるようにする

### DIFF
--- a/src/components/TaskCreate.tsx
+++ b/src/components/TaskCreate.tsx
@@ -51,6 +51,7 @@ export function TaskCreate() {
   async function handleAction(formData: FormData) {
     const title = (formData.get("title") as string)?.trim()
     if (!title) return
+    const body = (formData.get("body") as string)?.trim() || undefined
 
     startTransition(async () => {
       await createTaskAction({
@@ -59,6 +60,7 @@ export function TaskCreate() {
         priority: (formData.get("priority") as TaskPriority) || undefined,
         due: (formData.get("due") as string) || undefined,
         tags: selectedTags.length > 0 ? selectedTags : undefined,
+        body,
       })
       handleClose()
     })
@@ -111,6 +113,14 @@ export function TaskCreate() {
                 required
                 autoFocus
                 className="w-full rounded-xl border border-[rgba(255,0,204,0.3)] px-4 py-4 text-sm text-[#ffbbee] bg-[#0d0014] placeholder:text-[#553355] focus:outline-none focus:border-[#ff00cc]"
+                style={{ transition: "border-color 0.2s" }}
+              />
+
+              <textarea
+                name="body"
+                placeholder="BODY (optional)"
+                rows={3}
+                className="w-full rounded-xl border border-[rgba(255,0,204,0.3)] px-4 py-4 text-sm text-[#ffbbee] bg-[#0d0014] placeholder:text-[#553355] focus:outline-none focus:border-[#ff00cc] resize-none"
                 style={{ transition: "border-color 0.2s" }}
               />
 

--- a/src/lib/mock-tasks.ts
+++ b/src/lib/mock-tasks.ts
@@ -202,6 +202,7 @@ export function createMockTask(input: CreateTaskInput): Task {
     lastEditedTime: ts,
   }
   store.push(task)
+  if (input.body?.trim()) mockBlockStore.set(task.id, input.body)
   return task
 }
 

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -153,6 +153,16 @@ export async function createTask(input: CreateTaskInput): Promise<Task> {
     properties: properties as Parameters<typeof notion.pages.create>[0]["properties"],
   })
 
+  if (input.body?.trim()) {
+    const blocks = markdownToNotionBlocks(input.body)
+    if (blocks.length > 0) {
+      await notion.blocks.children.append({
+        block_id: page.id,
+        children: blocks as Parameters<typeof notion.blocks.children.append>[0]["children"],
+      })
+    }
+  }
+
   return pageToTask(page as PageObjectResponse)
 }
 

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -42,6 +42,7 @@ export type CreateTaskInput = {
   priority?: TaskPriority
   due?: string | null
   tags?: TaskTag[]
+  body?: string
   source?: string
   sourceUrl?: string
   parentTaskId?: string


### PR DESCRIPTION
## Summary
- タスク作成フォームにテキストエリア（BODY）を追加
- 入力された本文を Notion ページのブロックコンテンツとして保存
- モックタスクにも対応済み

## Test plan
- [x] ユニットテスト 131件 通過
- [x] Playwright e2e テスト 28件 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)