### PR TITLE
fix: ページインジケータの上下余白を揃える

### DIFF
--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -326,7 +326,7 @@ export function TaskManager({
         </div>
 
         {/* ページネーションドット */}
-        <div className="flex justify-center items-center gap-2 pb-1">
+        <div className="flex justify-center items-center gap-2">
           {FILTERS.map((f, i) => {
             const active = i === centerIndex
             return (


### PR DESCRIPTION
## Summary
- ページインジケータ（ページネーションドット）の上下余白が 上8px / 下12px でズレていたのを修正
- ドット div の `pb-1`（4px）を削除し、上下とも `gap-2`/`pb-2` の 8px に統一

## Test plan
- [x] `npm run test:unit` 全131件パス
- [x] `npx playwright test` 全28件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)