### PR TITLE
feat: アニメーションをサイバーパンク風に強化する

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,6 +62,36 @@ body::before {
   }
 }
 
+@keyframes dot-pulse {
+  0%, 100% { box-shadow: 0 0 6px rgba(255,0,204,0.7); }
+  50%       { box-shadow: 0 0 16px #ff00cc, 0 0 32px rgba(255,0,204,0.4); }
+}
+
+@keyframes spin-cyber {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes shimmer-bar {
+  0%   { background-position: -100% 0; }
+  100% { background-position: 100% 0; }
+}
+
+@layer utilities {
+  .animate-dot-pulse {
+    animation: dot-pulse 1.8s ease-in-out infinite;
+  }
+  .animate-spin-cyber {
+    animation: spin-cyber 0.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    filter: drop-shadow(0 0 4px #ff00cc);
+  }
+  .loading-bar-shimmer {
+    background: linear-gradient(90deg, #ff00cc 0%, #ff66ee 40%, #ffffff 50%, #ff66ee 60%, #ff00cc 100%);
+    background-size: 200% 100%;
+    animation: shimmer-bar 1.2s linear infinite;
+  }
+}
+
 /* スクロールバー */
 ::-webkit-scrollbar { width: 3px; }
 ::-webkit-scrollbar-track { background: var(--cyber-bg); }

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -271,10 +271,9 @@ export function TaskManager({
     <div className="flex flex-col flex-1 overflow-hidden">
       {/* ローディングバー */}
       <div
-        className={`h-0.5 transition-all duration-300 ${isPending ? "opacity-100" : "opacity-0"}`}
+        className={`h-0.5 loading-bar-shimmer transition-all duration-300 ${isPending ? "opacity-100" : "opacity-0"}`}
         style={{
           width: isPending ? "80%" : "0%",
-          backgroundColor: "#ff00cc",
           boxShadow: "0 0 8px #ff00cc",
         }}
       />
@@ -303,10 +302,10 @@ export function TaskManager({
             data-testid="refresh-button"
             disabled={isPending}
             onClick={() => startTransition(async () => { await refreshTasksAction() })}
-            className="flex-shrink-0 w-10 self-stretch rounded-xl border border-[rgba(255,0,204,0.3)] bg-[#160022] text-[#ff00cc] flex items-center justify-center hover:border-[#ff00cc] disabled:opacity-40 transition-colors"
+            className="flex-shrink-0 w-10 self-stretch rounded-xl border border-[rgba(255,0,204,0.3)] bg-[#160022] text-[#ff00cc] flex items-center justify-center hover:border-[#ff00cc] active:scale-95 disabled:opacity-40 transition-colors"
           >
             <svg
-              className={isPending ? "animate-spin" : ""}
+              className={isPending ? "animate-spin-cyber" : ""}
               xmlns="http://www.w3.org/2000/svg"
               width="18"
               height="18"
@@ -340,13 +339,16 @@ export function TaskManager({
                   setCenterIndex(i)
                   startTransition(async () => { await setFilterAction(f.key) })
                 }}
-                className="transition-all duration-200"
+                className={active ? "animate-dot-pulse" : ""}
                 style={{
+                  transition: active
+                    ? "width 400ms cubic-bezier(0.34, 1.56, 0.64, 1), background-color 200ms ease"
+                    : "width 250ms cubic-bezier(0.4, 0, 0.2, 1), background-color 200ms ease, box-shadow 250ms ease",
                   width: active ? "20px" : "8px",
                   height: "8px",
                   borderRadius: "4px",
                   backgroundColor: active ? "#ff00cc" : "rgba(153,102,136,0.4)",
-                  boxShadow: active ? "0 0 6px rgba(255,0,204,0.7)" : "none",
+                  boxShadow: active ? undefined : "none",
                 }}
               />
             )


### PR DESCRIPTION
## Summary
- **ローディングバー**: 単色ピンク → 白いハイライトが流れるシマーグラデーション（1.2s shimmer）
- **リロードボタン**: `animate-spin`(linear 1s) → eased spin(0.6s cubic-bezier) + ネオン `drop-shadow` + `active:scale-95` プレスフィードバック
- **ページインジケータ**: 拡張時に spring easing でバウンス感、アクティブドットがグローを呼吸する pulse アニメーション（1.8s）

## Test plan
- [x] `npm run test:unit` 全131件パス
- [x] `npx playwright test` 全28件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)