### PR TITLE
fix: ローディングバー完了時に右端まで伸びてからフェードアウトする

### DIFF
--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -110,6 +110,16 @@ export function TaskManager({
   initialTaskId?: string | null
 }) {
   const [isPending, startTransition] = useTransition()
+  const [completingBar, setCompletingBar] = useState(false)
+  const prevIsPendingRef = useRef(isPending)
+  useEffect(() => {
+    if (prevIsPendingRef.current && !isPending) {
+      setCompletingBar(true)
+      const timer = setTimeout(() => setCompletingBar(false), 400)
+      return () => clearTimeout(timer)
+    }
+    prevIsPendingRef.current = isPending
+  }, [isPending])
 
   const initialIndex = Math.max(0, FILTERS.findIndex((f) => f.key === currentFilter))
   const initialKey = FILTERS[initialIndex].key
@@ -271,9 +281,9 @@ export function TaskManager({
     <div className="flex flex-col flex-1 overflow-hidden">
       {/* ローディングバー */}
       <div
-        className={`h-0.5 loading-bar-shimmer transition-all duration-300 ${isPending ? "opacity-100" : "opacity-0"}`}
+        className={`h-0.5 loading-bar-shimmer transition-all duration-300 ${isPending || completingBar ? "opacity-100" : "opacity-0"}`}
         style={{
-          width: isPending ? "80%" : "0%",
+          width: completingBar ? "100%" : isPending ? "80%" : "0%",
           boxShadow: "0 0 8px #ff00cc",
         }}
       />


### PR DESCRIPTION
## Summary

- `isPending` が `true → false` に変わる瞬間に `completingBar` ステートを 400ms 有効にする
- バーの幅: ローディング中 80% → 完了直後 100%（`transition-all duration-300` でスムーズに伸びる）→ フェードアウト
- 完了しても 80% で止まりバーが突然消えていた UX を改善

## Test plan

- [x] ユニットテスト 131 件通過
- [x] Playwright テスト 28 件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)