### PR TITLE
refactor: 日付/時刻処理の重複を共通化する

### DIFF
--- a/src/components/DueDateTimeInput.tsx
+++ b/src/components/DueDateTimeInput.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { snapTimeTo5Min } from "@/lib/due-date"
+
+type Size = "default" | "compact"
+
+const VERTICAL_PADDING: Record<Size, string> = {
+  default: "py-3",
+  compact: "py-2",
+}
+
+export function DueDateTimeInput({
+  date,
+  time,
+  onChange,
+  size = "default",
+}: {
+  date: string
+  time: string
+  onChange: (date: string, time: string) => void
+  size?: Size
+}) {
+  const inputClass = `rounded-xl px-3 ${VERTICAL_PADDING[size]} text-sm text-[#ffbbee] bg-[#0d0014] focus:outline-none disabled:opacity-40`
+  const inputStyle = { border: "1px solid rgba(255,0,204,0.3)", colorScheme: "dark" as const }
+
+  return (
+    <div className="flex gap-2 items-center">
+      <input
+        type="date"
+        value={date}
+        onChange={(e) => {
+          const nextDate = e.target.value
+          onChange(nextDate, nextDate ? time : "")
+        }}
+        className={inputClass}
+        style={inputStyle}
+      />
+      <input
+        type="time"
+        value={time}
+        onChange={(e) => onChange(date, snapTimeTo5Min(e.target.value))}
+        disabled={!date}
+        step={300}
+        aria-label="期限の時刻"
+        className={inputClass}
+        style={inputStyle}
+      />
+    </div>
+  )
+}

--- a/src/components/TaskCreate.tsx
+++ b/src/components/TaskCreate.tsx
@@ -3,7 +3,8 @@
 import { useState, useRef, useTransition } from "react"
 import { useFormStatus } from "react-dom"
 import { createTaskAction } from "@/app/actions"
-import { buildDue, snapTimeTo5Min } from "@/lib/due-date"
+import { buildDue } from "@/lib/due-date"
+import { DueDateTimeInput } from "./DueDateTimeInput"
 import type { TaskStatus, TaskPriority, TaskTag } from "@/types/task"
 
 const TAG_OPTIONS: TaskTag[] = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
@@ -155,29 +156,14 @@ export function TaskCreate() {
 
               <div>
                 <label className="block text-xs text-[#996688] mb-2 tracking-widest uppercase">期限</label>
-                <div className="flex gap-2 items-center">
-                  <input
-                    type="date"
-                    value={dueDate}
-                    onChange={(e) => {
-                      const next = e.target.value
-                      setDueDate(next)
-                      if (!next) setDueTime("")
-                    }}
-                    className="rounded-xl px-3 py-3 text-sm text-[#ffbbee] bg-[#0d0014] focus:outline-none"
-                    style={{ border: "1px solid rgba(255,0,204,0.3)", colorScheme: "dark" }}
-                  />
-                  <input
-                    type="time"
-                    value={dueTime}
-                    onChange={(e) => setDueTime(snapTimeTo5Min(e.target.value))}
-                    disabled={!dueDate}
-                    step={300}
-                    aria-label="期限の時刻"
-                    className="rounded-xl px-3 py-3 text-sm text-[#ffbbee] bg-[#0d0014] focus:outline-none disabled:opacity-40"
-                    style={{ border: "1px solid rgba(255,0,204,0.3)", colorScheme: "dark" }}
-                  />
-                </div>
+                <DueDateTimeInput
+                  date={dueDate}
+                  time={dueTime}
+                  onChange={(d, t) => {
+                    setDueDate(d)
+                    setDueTime(t)
+                  }}
+                />
               </div>
 
               <div>

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -5,7 +5,8 @@ import type { Task, TaskComment, TaskStatus, TaskPriority, TaskTag } from "@/typ
 import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction, getTaskCommentsAction, createTaskCommentAction } from "@/app/actions"
 import { STATUS_OPTIONS, STATUS_STYLES } from "@/constants/styles"
 import { MarkdownPreview } from "./MarkdownPreview"
-import { parseDue, buildDue, snapTimeTo5Min } from "@/lib/due-date"
+import { parseDue, buildDue, snapTimeTo5Min, formatDueShort } from "@/lib/due-date"
+import { DueDateTimeInput } from "./DueDateTimeInput"
 
 const TAG_OPTIONS: TaskTag[] = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
 
@@ -268,10 +269,9 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
   }
 
   function handleDueChange(date: string, time: string) {
-    const nextTime = date ? snapTimeTo5Min(time) : ""
     setEditDate(date)
-    setEditTime(nextTime)
-    save({ due: buildDue(date, nextTime) })
+    setEditTime(time)
+    save({ due: buildDue(date, time) })
   }
 
   function toggleTag(tag: TaskTag) {
@@ -361,25 +361,12 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
           </Row>
 
           <Row label="期限">
-            <div className="flex gap-2 items-center">
-              <input
-                type="date"
-                value={editDate}
-                onChange={(e) => handleDueChange(e.target.value, editTime)}
-                className="rounded-xl px-3 py-2 text-sm text-[#ffbbee] bg-[#0d0014] focus:outline-none"
-                style={{ border: "1px solid rgba(255,0,204,0.3)", colorScheme: "dark" }}
-              />
-              <input
-                type="time"
-                value={editTime}
-                onChange={(e) => handleDueChange(editDate, e.target.value)}
-                disabled={!editDate}
-                step={300}
-                aria-label="期限の時刻"
-                className="rounded-xl px-3 py-2 text-sm text-[#ffbbee] bg-[#0d0014] focus:outline-none disabled:opacity-40"
-                style={{ border: "1px solid rgba(255,0,204,0.3)", colorScheme: "dark" }}
-              />
-            </div>
+            <DueDateTimeInput
+              date={editDate}
+              time={editTime}
+              onChange={handleDueChange}
+              size="compact"
+            />
           </Row>
 
           <Row label="タグ">
@@ -531,7 +518,7 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
                     <span className="text-xs text-[#ff00cc]">{c.author}</span>
                     <span className="text-xs text-[#553355]">·</span>
                     <span className="text-xs text-[#553355]">
-                      {new Date(c.createdTime).toLocaleDateString("ja-JP", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                      {formatDueShort(c.createdTime)}
                     </span>
                   </div>
                   <MarkdownPreview content={c.text} />

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -4,7 +4,7 @@ import { useOptimistic, useTransition, useRef, useState } from "react"
 import type { Task, TaskStatus } from "@/types/task"
 import { updateTaskStatus } from "@/app/actions"
 import { STATUS_OPTIONS, STATUS_STYLES, PRIORITY_STYLES } from "@/constants/styles"
-import { formatDueShort } from "@/lib/due-date"
+import { formatDueShort, isOverdue } from "@/lib/due-date"
 
 export function TaskItem({ task, onSelect }: { task: Task; onSelect: (id: string) => void }) {
   const [, startTransition] = useTransition()
@@ -14,10 +14,7 @@ export function TaskItem({ task, onSelect }: { task: Task; onSelect: (id: string
 
   const status = optimisticStatus
   const statusStyle = status ? (STATUS_STYLES[status] ?? STATUS_STYLES["未着手"]) : STATUS_STYLES["未着手"]
-  const due = task.due ? new Date(task.due) : null
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const isOverdue = due !== null && due < today
+  const overdue = isOverdue(task.due)
 
   return (
     <div
@@ -65,9 +62,9 @@ export function TaskItem({ task, onSelect }: { task: Task; onSelect: (id: string
             {PRIORITY_STYLES[task.priority].label}
           </span>
         )}
-        {due && task.due && (
-          <span className={`text-xs ${isOverdue ? "text-[#ff3355]" : "text-[#996688]"}`}>
-            {isOverdue ? "⚠ " : ""}{formatDueShort(task.due)}
+        {task.due && (
+          <span className={`text-xs ${overdue ? "text-[#ff3355]" : "text-[#996688]"}`}>
+            {overdue ? "⚠ " : ""}{formatDueShort(task.due)}
           </span>
         )}
         {task.tags.slice(0, 2).map((tag) => (

--- a/src/components/__tests__/TaskItem.test.tsx
+++ b/src/components/__tests__/TaskItem.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { TaskItem } from "@/components/TaskItem"
+import { formatDueShort } from "@/lib/due-date"
 import type { Task } from "@/types/task"
 
 vi.mock("@/app/actions", () => ({
@@ -73,10 +74,7 @@ describe("TaskItem レンダリング", () => {
     futureDate.setDate(futureDate.getDate() + 7)
     const due = futureDate.toISOString().split("T")[0]
     render(<TaskItem task={makeTask({ due })} onSelect={vi.fn()} />)
-    // 期限表示あり
-    const d = new Date(due)
-    const formatted = `${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`
-    const dueDateEl = screen.getByText(formatted)
+    const dueDateEl = screen.getByText(formatDueShort(due))
     expect(dueDateEl).toBeInTheDocument()
     expect(dueDateEl.textContent).not.toContain("⚠")
   })

--- a/src/lib/__tests__/due-date.test.ts
+++ b/src/lib/__tests__/due-date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { parseDue, buildDue, formatDueShort, snapTimeTo5Min } from "@/lib/due-date"
+import { parseDue, buildDue, formatDueShort, snapTimeTo5Min, isOverdue } from "@/lib/due-date"
 
 describe("parseDue", () => {
   it("null は { date: '', time: '' }", () => {
@@ -103,5 +103,36 @@ describe("formatDueShort", () => {
 
   it("不正な文字列はそのまま返す", () => {
     expect(formatDueShort("not-a-date-T")).toBe("not-a-date-T")
+  })
+})
+
+describe("isOverdue", () => {
+  it("null は false", () => {
+    expect(isOverdue(null)).toBe(false)
+  })
+
+  it("不正な文字列は false", () => {
+    expect(isOverdue("not-a-date")).toBe(false)
+  })
+
+  it("過去日は true", () => {
+    expect(isOverdue("2020-01-01")).toBe(true)
+  })
+
+  it("未来日は false", () => {
+    const future = new Date()
+    future.setDate(future.getDate() + 7)
+    const yyyy = future.getFullYear()
+    const mm = String(future.getMonth() + 1).padStart(2, "0")
+    const dd = String(future.getDate()).padStart(2, "0")
+    expect(isOverdue(`${yyyy}-${mm}-${dd}`)).toBe(false)
+  })
+
+  it("当日（日付のみ）は false（その日が終わるまで overdue ではない）", () => {
+    const today = new Date()
+    const yyyy = today.getFullYear()
+    const mm = String(today.getMonth() + 1).padStart(2, "0")
+    const dd = String(today.getDate()).padStart(2, "0")
+    expect(isOverdue(`${yyyy}-${mm}-${dd}`)).toBe(false)
   })
 })

--- a/src/lib/due-date.ts
+++ b/src/lib/due-date.ts
@@ -54,3 +54,13 @@ export function formatDueShort(due: string): string {
   if (Number.isNaN(d.getTime())) return due
   return `${pad2(d.getMonth() + 1)}/${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`
 }
+
+// 期限切れ判定。null は false。日付のみの値は当日 0:00 と比較されるため、当日中は overdue にならない。
+export function isOverdue(due: string | null): boolean {
+  if (!due) return false
+  const d = new Date(due)
+  if (Number.isNaN(d.getTime())) return false
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  return d < today
+}


### PR DESCRIPTION
## Summary
- `isOverdue` を `due-date.ts` に抽出し `TaskItem` の期限切れ判定をユーティリティ経由に
- `date` + `time` 入力ペアを `DueDateTimeInput` コンポーネントへ切り出し `TaskCreate` / `TaskDetail` で共有（snap-to-5min と date 連動の disable 処理も内包）
- コメント timestamp を `toLocaleDateString` から `formatDueShort` に統一し `04/28 18:00` 形式（ゼロ埋め）に揃える

## Test plan
- [x] `npm run test:unit` (171/171 通過、`isOverdue` のテスト追加)
- [x] `npx playwright test` (30/30 通過)
- [x] dev サーバーで動作確認（タスク作成・期限編集・コメント表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)