### PR TITLE
test: Playwright テストの安定性を改善する

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -4,12 +4,13 @@ import * as fs from "fs"
 const AUTH_FILE = "e2e/.auth/user.json"
 
 setup("authenticate", async ({ page }) => {
+  setup.setTimeout(60_000)
   await page.goto("/login")
   await page.getByLabel("ユーザー名").fill(process.env.APP_USERNAME!)
   await page.getByLabel("パスワード").fill(process.env.APP_PASSWORD!)
   await page.getByRole("button", { name: "ACCESS" }).click()
-  await page.waitForURL("/")
-  await expect(page.locator("h1")).toContainText("To-do")
+  await page.waitForURL("/", { timeout: 15_000 })
+  await expect(page.locator("h1")).toContainText("To-do", { timeout: 10_000 })
 
   fs.mkdirSync("e2e/.auth", { recursive: true })
   await page.context().storageState({ path: AUTH_FILE })

--- a/e2e/swipe.spec.ts
+++ b/e2e/swipe.spec.ts
@@ -10,8 +10,9 @@ async function resetAndWait(page: Page) {
   await page.context().addCookies([{ name: "filter", value: "active", domain: "localhost", path: "/" }])
   await page.goto("/reset")
   await expect(page.locator(`${CENTER} ${TASK_ITEM}`).first()).toBeVisible({ timeout: 15_000 })
-  // バックグラウンドプリフェッチ（隣接パネル取得）が完了するまで待つ
-  await page.waitForLoadState("networkidle")
+  // 隣接パネル（左右フィルター）のプリフェッチ完了を待つ。
+  // バックグラウンドリクエストが詰まっても永遠に待たないよう timeout を明示する。
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {})
 }
 
 // CDP Input.dispatchTouchEvent でスワイプをシミュレート（Chromium のみ）

--- a/e2e/task-detail.spec.ts
+++ b/e2e/task-detail.spec.ts
@@ -45,7 +45,7 @@ test.describe("タスク詳細ボトムシート", () => {
     await expect(page.locator('input[aria-label="タイトル"]')).toBeVisible({ timeout: 3_000 })
     await expect(page.locator('input[type="date"]')).toBeVisible()
     await expect(page.locator('input[aria-label="期限の時刻"]')).toBeVisible()
-    await expect(page.locator('select').first()).toBeVisible()
+    await expect(page.locator("[data-testid='priority-select']")).toBeVisible()
   })
 
   test("SAVE CHANGESボタンが存在しない（即時保存方式）", async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,23 +6,24 @@ dotenv.config({ path: path.resolve(__dirname, ".env.local"), override: true })
 
 export default defineConfig({
   testDir: "./e2e",
-  timeout: 45_000,
+  timeout: 60_000,
   retries: 2,
   workers: 1,
   fullyParallel: false,
-  reporter: "list",
+  reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:3000",
-    trace: "retain-on-failure",
+    trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
   expect: {
-    timeout: 10_000,
+    timeout: 15_000,
   },
   projects: [
     {
       name: "setup",
       testMatch: "auth.setup.ts",
+      retries: 2,
     },
     {
       name: "iPhone 15 (touch)",
@@ -60,6 +61,6 @@ export default defineConfig({
     command: "docker compose rm -sf dev && docker compose up --force-recreate dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    timeout: 180_000,
   },
 })

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -348,6 +348,7 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
         <div className="space-y-4">
           <Row label="Priority">
             <select
+              data-testid="priority-select"
               value={editPriority}
               onChange={(e) => handlePriorityChange(e.target.value as TaskPriority | "")}
               className="rounded-xl px-3 py-2 text-sm bg-[#0d0014] text-[#ffbbee] focus:outline-none"


### PR DESCRIPTION
## Summary

- `playwright.config.ts` の各種 timeout を実態に合わせ拡張（Docker 再生成 / HMR 遅延 / リスト再描画の余裕を確保）
- `swipe.spec.ts` の `waitForLoadState("networkidle")` に timeout を付与し無限待機による flaky を回避
- ボトムシート内 priority select に `data-testid="priority-select"` を付与し、`select.first()` 依存を解消
- `auth.setup.ts` の各ステップに timeout を明示し、認証失敗時の原因切り分けを容易化
- trace を `on-first-retry` に変更、HTML reporter を追加して失敗時の調査を簡便化

## Test plan

- [x] `npm run test:unit` 全 171 件パス
- [x] `npx playwright test` を 2 回連続実行: 1 回目は 29 passed + 1 flaky (retry success)、2 回目は 30 passed (flaky 0 件)
- [ ] マージ前に CI/レビュアー側で同様のテスト実行を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)