### PR TITLE
feat: タグ選択肢を Notion API から動的に取得する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers"
 import { auth, signOut } from "@/auth"
-import { getTasks } from "@/lib/notion"
+import { getTasks, getTagOptions } from "@/lib/notion"
 import { TaskManager } from "@/components/TaskManager"
 import { HydrationCheck } from "@/components/HydrationCheck"
 import { getQueryStatuses } from "@/constants/filters"
@@ -15,9 +15,10 @@ export default async function Page({
   const { task: taskParam } = await searchParams
   const initialTaskId = typeof taskParam === "string" ? taskParam : null
 
-  const [session, tasks] = await Promise.all([
+  const [session, tasks, tagOptions] = await Promise.all([
     auth(),
     getTasks({ statuses: getQueryStatuses(filter) }),
+    getTagOptions(),
   ])
 
   return (
@@ -42,7 +43,7 @@ export default async function Page({
       </header>
 
       <HydrationCheck />
-      <TaskManager tasks={tasks} currentFilter={filter} initialTaskId={initialTaskId} />
+      <TaskManager tasks={tasks} tagOptions={tagOptions} currentFilter={filter} initialTaskId={initialTaskId} />
     </div>
   )
 }

--- a/src/components/TaskCreate.tsx
+++ b/src/components/TaskCreate.tsx
@@ -5,9 +5,7 @@ import { useFormStatus } from "react-dom"
 import { createTaskAction } from "@/app/actions"
 import { buildDue } from "@/lib/due-date"
 import { DueDateTimeInput } from "./DueDateTimeInput"
-import type { TaskStatus, TaskPriority, TaskTag } from "@/types/task"
-
-const TAG_OPTIONS: TaskTag[] = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
+import type { TaskStatus, TaskPriority } from "@/types/task"
 
 function SubmitButton() {
   const { pending } = useFormStatus()
@@ -27,15 +25,15 @@ function SubmitButton() {
   )
 }
 
-export function TaskCreate() {
+export function TaskCreate({ tagOptions }: { tagOptions: string[] }) {
   const [open, setOpen] = useState(false)
-  const [selectedTags, setSelectedTags] = useState<TaskTag[]>([])
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [dueDate, setDueDate] = useState("")
   const [dueTime, setDueTime] = useState("")
   const [, startTransition] = useTransition()
   const formRef = useRef<HTMLFormElement>(null)
 
-  function toggleTag(tag: TaskTag) {
+  function toggleTag(tag: string) {
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
     )
@@ -169,7 +167,7 @@ export function TaskCreate() {
               <div>
                 <p className="text-xs text-[#996688] mb-2 tracking-widest uppercase">タグ</p>
                 <div className="flex flex-wrap gap-2">
-                  {TAG_OPTIONS.map((tag) => (
+                  {tagOptions.map((tag) => (
                     <button
                       key={tag}
                       type="button"

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -1,16 +1,14 @@
 "use client"
 
 import { useTransition, useState, useEffect, useRef } from "react"
-import type { Task, TaskComment, TaskStatus, TaskPriority, TaskTag } from "@/types/task"
+import type { Task, TaskComment, TaskStatus, TaskPriority } from "@/types/task"
 import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction, getTaskCommentsAction, createTaskCommentAction } from "@/app/actions"
 import { STATUS_OPTIONS, STATUS_STYLES } from "@/constants/styles"
 import { MarkdownPreview } from "./MarkdownPreview"
 import { parseDue, buildDue, snapTimeTo5Min, formatDueShort } from "@/lib/due-date"
 import { DueDateTimeInput } from "./DueDateTimeInput"
 
-const TAG_OPTIONS: TaskTag[] = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
-
-export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void }) {
+export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptions: string[]; onClose: () => void }) {
   const [isPending, startTransition] = useTransition()
   const [visible, setVisible] = useState(false)
 
@@ -20,7 +18,7 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
   const initialDue = parseDue(task.due)
   const [editDate, setEditDate] = useState(initialDue.date)
   const [editTime, setEditTime] = useState(snapTimeTo5Min(initialDue.time))
-  const [editTags, setEditTags] = useState<TaskTag[]>(task.tags)
+  const [editTags, setEditTags] = useState<string[]>(task.tags)
 
   const [blocks, setBlocks] = useState<string | null>(null)
   const [isLoadingBlocks, setIsLoadingBlocks] = useState(true)
@@ -274,7 +272,7 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
     save({ due: buildDue(date, time) })
   }
 
-  function toggleTag(tag: TaskTag) {
+  function toggleTag(tag: string) {
     const next = editTags.includes(tag)
       ? editTags.filter((t) => t !== tag)
       : [...editTags, tag]
@@ -372,7 +370,7 @@ export function TaskDetail({ task, onClose }: { task: Task; onClose: () => void 
 
           <Row label="タグ">
             <div className="flex flex-wrap gap-2">
-              {TAG_OPTIONS.map((tag) => (
+              {tagOptions.map((tag) => (
                 <button
                   key={tag}
                   type="button"

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -109,10 +109,12 @@ function getPanelKeys(idx: number) {
 
 export function TaskManager({
   tasks,
+  tagOptions,
   currentFilter,
   initialTaskId,
 }: {
   tasks: Task[]
+  tagOptions: string[]
   currentFilter: string
   initialTaskId?: string | null
 }) {
@@ -418,9 +420,9 @@ export function TaskManager({
         </div>
       </main>
 
-      <TaskCreate />
+      <TaskCreate tagOptions={tagOptions} />
       {selectedTask && (
-        <TaskDetail task={selectedTask} onClose={() => setSelectedTaskId(null)} />
+        <TaskDetail task={selectedTask} tagOptions={tagOptions} onClose={() => setSelectedTaskId(null)} />
       )}
     </div>
   )

--- a/src/components/__tests__/TaskCreate.test.tsx
+++ b/src/components/__tests__/TaskCreate.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { TaskCreate } from "@/components/TaskCreate"
 
+const TAG_OPTIONS = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
+
 vi.mock("@/app/actions", () => ({
   createTaskAction: vi.fn().mockResolvedValue(undefined),
 }))
@@ -16,17 +18,17 @@ vi.mock("react-dom", async (importActual) => {
 
 describe("TaskCreate FAB", () => {
   it("FAB が aria-label 付きでレンダリングされる", () => {
-    render(<TaskCreate />)
+    render(<TaskCreate tagOptions={TAG_OPTIONS} />)
     expect(screen.getByRole("button", { name: "タスクを追加" })).toBeInTheDocument()
   })
 
   it("初期状態でフォームは非表示", () => {
-    render(<TaskCreate />)
+    render(<TaskCreate tagOptions={TAG_OPTIONS} />)
     expect(screen.queryByText("✦ New Task")).not.toBeInTheDocument()
   })
 
   it("FAB クリックでフォームが表示される", () => {
-    render(<TaskCreate />)
+    render(<TaskCreate tagOptions={TAG_OPTIONS} />)
     fireEvent.click(screen.getByRole("button", { name: "タスクを追加" }))
     expect(screen.getByText("✦ New Task")).toBeInTheDocument()
   })
@@ -34,7 +36,7 @@ describe("TaskCreate FAB", () => {
 
 describe("TaskCreate フォーム表示", () => {
   beforeEach(() => {
-    render(<TaskCreate />)
+    render(<TaskCreate tagOptions={TAG_OPTIONS} />)
     fireEvent.click(screen.getByRole("button", { name: "タスクを追加" }))
   })
 
@@ -65,7 +67,7 @@ describe("TaskCreate フォーム表示", () => {
 
 describe("TaskCreate タグトグル", () => {
   beforeEach(() => {
-    render(<TaskCreate />)
+    render(<TaskCreate tagOptions={TAG_OPTIONS} />)
     fireEvent.click(screen.getByRole("button", { name: "タスクを追加" }))
   })
 
@@ -93,7 +95,7 @@ describe("TaskCreate タグトグル", () => {
 
 describe("TaskCreate バックドロップで閉じる", () => {
   it("バックドロップクリックでフォームが閉じる", () => {
-    const { container } = render(<TaskCreate />)
+    const { container } = render(<TaskCreate tagOptions={TAG_OPTIONS} />)
     fireEvent.click(screen.getByRole("button", { name: "タスクを追加" }))
     expect(screen.getByText("✦ New Task")).toBeInTheDocument()
 
@@ -105,7 +107,7 @@ describe("TaskCreate バックドロップで閉じる", () => {
 
 describe("TaskCreate フォーム送信", () => {
   beforeEach(() => {
-    render(<TaskCreate />)
+    render(<TaskCreate tagOptions={TAG_OPTIONS} />)
     fireEvent.click(screen.getByRole("button", { name: "タスクを追加" }))
   })
 

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -4,6 +4,8 @@ import { TaskDetail } from "@/components/TaskDetail"
 import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction } from "@/app/actions"
 import type { Task } from "@/types/task"
 
+const TAG_OPTIONS = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
+
 vi.mock("@/app/actions", () => ({
   updateTaskAction: vi.fn().mockResolvedValue(undefined),
   getTaskBlocksAction: vi.fn().mockResolvedValue(""),
@@ -62,37 +64,37 @@ function deferred<T>() {
 
 describe("TaskDetail レンダリング", () => {
   it("タスクタイトルを表示する", () => {
-    render(<TaskDetail task={makeTask({ title: "買い物リスト" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ title: "買い物リスト" })} onClose={() => {}} />)
     expect(screen.getByDisplayValue("買い物リスト")).toBeInTheDocument()
   })
 
   it("現在のステータスバッジを表示する", () => {
-    render(<TaskDetail task={makeTask({ status: "進行中" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ status: "進行中" })} onClose={() => {}} />)
     expect(screen.getAllByText("進行中").length).toBeGreaterThan(0)
   })
 
   it("status が null のとき「未着手」バッジを表示する", () => {
-    render(<TaskDetail task={makeTask({ status: null })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ status: null })} onClose={() => {}} />)
     expect(screen.getAllByText("未着手").length).toBeGreaterThan(0)
   })
 
   it("priority が high のとき「🚨 High」を表示する", () => {
-    render(<TaskDetail task={makeTask({ priority: "high" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ priority: "high" })} onClose={() => {}} />)
     expect(screen.getByText("🚨 High")).toBeInTheDocument()
   })
 
   it("priority が medium のとき「⚠️ Med」を表示する", () => {
-    render(<TaskDetail task={makeTask({ priority: "medium" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ priority: "medium" })} onClose={() => {}} />)
     expect(screen.getByText("⚠️ Med")).toBeInTheDocument()
   })
 
   it("priority が low のとき「💤 Low」を表示する", () => {
-    render(<TaskDetail task={makeTask({ priority: "low" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ priority: "low" })} onClose={() => {}} />)
     expect(screen.getByText("💤 Low")).toBeInTheDocument()
   })
 
   it("priority が null のとき priority select が未設定になる", () => {
-    render(<TaskDetail task={makeTask({ priority: null })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ priority: null })} onClose={() => {}} />)
     expect(screen.getByDisplayValue("未設定")).toBeInTheDocument()
   })
 
@@ -100,47 +102,47 @@ describe("TaskDetail レンダリング", () => {
     const future = new Date()
     future.setDate(future.getDate() + 7)
     const due = future.toISOString().split("T")[0]
-    render(<TaskDetail task={makeTask({ due })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due })} onClose={() => {}} />)
     expect(screen.getByDisplayValue(due)).toBeInTheDocument()
   })
 
   it("過去の due date が date input に反映される", () => {
-    render(<TaskDetail task={makeTask({ due: "2020-01-01" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due: "2020-01-01" })} onClose={() => {}} />)
     expect(screen.getByDisplayValue("2020-01-01")).toBeInTheDocument()
   })
 
   it("due が null のとき日付を表示しない", () => {
-    render(<TaskDetail task={makeTask({ due: null })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due: null })} onClose={() => {}} />)
     expect(screen.queryByText(/\d{4}年\d+月\d+日/)).not.toBeInTheDocument()
   })
 
   it("時刻 input が描画される", () => {
-    render(<TaskDetail task={makeTask({ due: null })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due: null })} onClose={() => {}} />)
     expect(screen.getByLabelText("期限の時刻")).toBeInTheDocument()
   })
 
   it("時刻 input は 5 分刻みヒント（step=300 秒）を持つ", () => {
-    render(<TaskDetail task={makeTask({ due: null })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due: null })} onClose={() => {}} />)
     expect(screen.getByLabelText("期限の時刻")).toHaveAttribute("step", "300")
   })
 
   it("時刻 input は type=time", () => {
-    render(<TaskDetail task={makeTask({ due: null })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due: null })} onClose={() => {}} />)
     expect(screen.getByLabelText("期限の時刻")).toHaveAttribute("type", "time")
   })
 
   it("date が null のとき時刻 input は disabled", () => {
-    render(<TaskDetail task={makeTask({ due: null })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due: null })} onClose={() => {}} />)
     expect(screen.getByLabelText("期限の時刻")).toBeDisabled()
   })
 
   it("date が設定済みなら時刻 input は活性", () => {
-    render(<TaskDetail task={makeTask({ due: "2026-04-30" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due: "2026-04-30" })} onClose={() => {}} />)
     expect(screen.getByLabelText("期限の時刻")).not.toBeDisabled()
   })
 
   it("時刻付き due は時刻 input に反映される", () => {
-    render(<TaskDetail task={makeTask({ due: "2026-04-30T18:30:00.000+09:00" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ due: "2026-04-30T18:30:00.000+09:00" })} onClose={() => {}} />)
     const dateInput = document.querySelector("input[type='date']") as HTMLInputElement
     expect(dateInput.value).toMatch(/^\d{4}-\d{2}-\d{2}$/)
     const timeInput = screen.getByLabelText("期限の時刻") as HTMLInputElement
@@ -148,34 +150,34 @@ describe("TaskDetail レンダリング", () => {
   })
 
   it("タグを表示する", () => {
-    render(<TaskDetail task={makeTask({ tags: ["Tech", "Blog"] })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ tags: ["Tech", "Blog"] })} onClose={() => {}} />)
     expect(screen.getByText("Tech")).toBeInTheDocument()
     expect(screen.getByText("Blog")).toBeInTheDocument()
   })
 
   it("source を表示する", () => {
-    render(<TaskDetail task={makeTask({ source: "GitHub" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ source: "GitHub" })} onClose={() => {}} />)
     expect(screen.getByText("GitHub")).toBeInTheDocument()
   })
 
   it("sourceUrl をリンクとして表示する", () => {
-    render(<TaskDetail task={makeTask({ sourceUrl: "https://example.com" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ sourceUrl: "https://example.com" })} onClose={() => {}} />)
     const link = screen.getByText("https://example.com")
     expect(link.closest("a")).toHaveAttribute("href", "https://example.com")
   })
 
   it("子タスク数を表示する", () => {
-    render(<TaskDetail task={makeTask({ childTaskIds: ["c1", "c2"] })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ childTaskIds: ["c1", "c2"] })} onClose={() => {}} />)
     expect(screen.getByText("2件")).toBeInTheDocument()
   })
 
   it("親タスク数を表示する", () => {
-    render(<TaskDetail task={makeTask({ parentTaskIds: ["p1"] })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ parentTaskIds: ["p1"] })} onClose={() => {}} />)
     expect(screen.getByText("1件")).toBeInTheDocument()
   })
 
   it("Notion リンクが正しい href を持つ", () => {
-    render(<TaskDetail task={makeTask({ url: "https://notion.so/abc" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ url: "https://notion.so/abc" })} onClose={() => {}} />)
     const link = screen.getByText(/Open in Notion/)
     expect(link.closest("a")).toHaveAttribute("href", "https://notion.so/abc")
   })
@@ -186,7 +188,7 @@ describe("TaskDetail フィールド変更", () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
-    render(<TaskDetail task={makeTask({ id: "t1", status: "未着手" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", status: "未着手" })} onClose={() => {}} />)
     const selects = screen.getAllByRole("combobox")
     fireEvent.change(selects[0], { target: { value: "進行中" } })
 
@@ -196,7 +198,7 @@ describe("TaskDetail フィールド変更", () => {
   })
 
   it("ステータス変更後にバッジが即時更新される", async () => {
-    render(<TaskDetail task={makeTask({ status: "未着手" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ status: "未着手" })} onClose={() => {}} />)
     const selects = screen.getAllByRole("combobox")
     fireEvent.change(selects[0], { target: { value: "完了" } })
 
@@ -209,7 +211,7 @@ describe("TaskDetail フィールド変更", () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
-    render(<TaskDetail task={makeTask({ id: "t1" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1" })} onClose={() => {}} />)
     const selects = screen.getAllByRole("combobox")
     fireEvent.change(selects[1], { target: { value: "high" } })
 
@@ -222,7 +224,7 @@ describe("TaskDetail フィールド変更", () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
-    render(<TaskDetail task={makeTask({ id: "t1", tags: [] })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", tags: [] })} onClose={() => {}} />)
     fireEvent.click(screen.getByText("Tech"))
 
     await waitFor(() => {
@@ -234,7 +236,7 @@ describe("TaskDetail フィールド変更", () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
-    render(<TaskDetail task={makeTask({ id: "t1", due: "2026-04-30" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", due: "2026-04-30" })} onClose={() => {}} />)
     fireEvent.change(screen.getByLabelText("期限の時刻"), { target: { value: "18:35" } })
 
     await waitFor(() => {
@@ -251,7 +253,7 @@ describe("TaskDetail フィールド変更", () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
-    render(<TaskDetail task={makeTask({ id: "t1", due: "2026-04-30" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", due: "2026-04-30" })} onClose={() => {}} />)
     const timeInput = screen.getByLabelText("期限の時刻") as HTMLInputElement
     fireEvent.change(timeInput, { target: { value: "18:33" } })
 
@@ -270,7 +272,7 @@ describe("TaskDetail フィールド変更", () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
-    render(<TaskDetail task={makeTask({ id: "t1", due: "2026-04-30T18:00:00.000+09:00" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", due: "2026-04-30T18:00:00.000+09:00" })} onClose={() => {}} />)
     fireEvent.change(screen.getByLabelText("期限の時刻"), { target: { value: "" } })
 
     await waitFor(() => {
@@ -282,7 +284,7 @@ describe("TaskDetail フィールド変更", () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
-    render(<TaskDetail task={makeTask({ id: "t1", due: "2026-04-30T18:00:00.000+09:00" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", due: "2026-04-30T18:00:00.000+09:00" })} onClose={() => {}} />)
     const dateInput = document.querySelector("input[type='date']") as HTMLInputElement
     fireEvent.change(dateInput, { target: { value: "" } })
 
@@ -296,7 +298,7 @@ describe("TaskDetail フィールド変更", () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
-    render(<TaskDetail task={makeTask({ id: "t1", title: "旧タイトル" })} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", title: "旧タイトル" })} onClose={() => {}} />)
     const titleInput = screen.getByRole("textbox", { name: "タイトル" })
     fireEvent.change(titleInput, { target: { value: "新タイトル" } })
     fireEvent.blur(titleInput)
@@ -311,7 +313,7 @@ describe("TaskDetail 本文編集", () => {
   it("取得した本文を表示する", async () => {
     vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("## 本文見出し\n\n- 箇条書き")
 
-    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
 
     expect(await screen.findByText("本文見出し")).toBeInTheDocument()
     expect(screen.getByText("箇条書き")).toBeInTheDocument()
@@ -321,7 +323,7 @@ describe("TaskDetail 本文編集", () => {
     const updateBlocksMock = vi.mocked(updateTaskBlocksAction)
     vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("元の本文")
 
-    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
 
     await screen.findByText("元の本文")
     fireEvent.click(screen.getByRole("button", { name: "編集" }))
@@ -340,7 +342,7 @@ describe("TaskDetail 本文編集", () => {
   it("本文中の URL がクリッカブルリンクになる", async () => {
     vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("詳細は https://example.com を参照")
 
-    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
 
     const link = await screen.findByRole("link", { name: "https://example.com" })
     expect(link).toHaveAttribute("href", "https://example.com")
@@ -360,7 +362,7 @@ describe("TaskDetail 本文編集", () => {
   ])("URL 末尾の %s が URL に含まれない", async (_, bodyText) => {
     vi.mocked(getTaskBlocksAction).mockResolvedValueOnce(bodyText)
 
-    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
 
     const link = await screen.findByRole("link", { name: "https://example.com" })
     expect(link).toHaveAttribute("href", "https://example.com")
@@ -369,7 +371,7 @@ describe("TaskDetail 本文編集", () => {
   it("本文取得に失敗してもローディングから復帰する", async () => {
     vi.mocked(getTaskBlocksAction).mockRejectedValueOnce(new Error("load failed"))
 
-    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
 
     expect(await screen.findByText("本文の読み込みに失敗しました。")).toBeInTheDocument()
     expect(screen.getByText("本文なし")).toBeInTheDocument()
@@ -379,7 +381,7 @@ describe("TaskDetail 本文編集", () => {
     vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("元の本文")
     vi.mocked(updateTaskBlocksAction).mockRejectedValueOnce(new Error("save failed"))
 
-    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
 
     await screen.findByText("元の本文")
     fireEvent.click(screen.getByRole("button", { name: "編集" }))
@@ -405,9 +407,9 @@ describe("TaskDetail 本文編集", () => {
       return Promise.resolve("")
     })
 
-    const { rerender } = render(<TaskDetail task={makeTask({ id: "t1" })} onClose={() => {}} />)
+    const { rerender } = render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1" })} onClose={() => {}} />)
 
-    rerender(<TaskDetail task={makeTask({ id: "t2", url: "https://notion.so/t2" })} onClose={() => {}} />)
+    rerender(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t2", url: "https://notion.so/t2" })} onClose={() => {}} />)
 
     await act(async () => {
       second.resolve("新しい本文")
@@ -430,7 +432,7 @@ describe("TaskDetail 閉じる動作", () => {
   it("ハンドルボタンクリックで onClose が 280ms 後に呼ばれる", async () => {
     vi.useFakeTimers()
     const onClose = vi.fn()
-    render(<TaskDetail task={makeTask()} onClose={onClose} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={onClose} />)
 
     // ハンドルボタンは最初のボタン
     const handleBtn = screen.getAllByRole("button")[0]
@@ -445,7 +447,7 @@ describe("TaskDetail 閉じる動作", () => {
   it("バックドロップクリックで onClose が 280ms 後に呼ばれる", async () => {
     vi.useFakeTimers()
     const onClose = vi.fn()
-    const { container } = render(<TaskDetail task={makeTask()} onClose={onClose} />)
+    const { container } = render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={onClose} />)
 
     const backdrop = container.querySelector('[class*="bg-black"]') as HTMLElement
     fireEvent.click(backdrop)
@@ -460,13 +462,13 @@ describe("TaskDetail 閉じる動作", () => {
 describe("TaskDetail スワイプ動作", () => {
   it("マウント時に body.style.overflow が hidden になる", () => {
     document.body.style.overflow = ""
-    render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
     expect(document.body.style.overflow).toBe("hidden")
   })
 
   it("アンマウント時に body.style.overflow が元に戻る", () => {
     document.body.style.overflow = "auto"
-    const { unmount } = render(<TaskDetail task={makeTask()} onClose={() => {}} />)
+    const { unmount } = render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
     unmount()
     expect(document.body.style.overflow).toBe("auto")
   })
@@ -474,7 +476,7 @@ describe("TaskDetail スワイプ動作", () => {
   it("80px 以上スワイプで onClose が 280ms 後に呼ばれる", () => {
     vi.useFakeTimers()
     const onClose = vi.fn()
-    const { container } = render(<TaskDetail task={makeTask()} onClose={onClose} />)
+    const { container } = render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={onClose} />)
 
     const panel = container.querySelector(".rounded-t-2xl") as HTMLElement
     act(() => {
@@ -491,7 +493,7 @@ describe("TaskDetail スワイプ動作", () => {
 
   it("80px 未満スワイプでは onClose は呼ばれない", () => {
     const onClose = vi.fn()
-    const { container } = render(<TaskDetail task={makeTask()} onClose={onClose} />)
+    const { container } = render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={onClose} />)
 
     const panel = container.querySelector(".rounded-t-2xl") as HTMLElement
     fireEvent.touchStart(panel, { touches: [{ clientY: 0 }] })

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -81,7 +81,7 @@ afterEach(() => {
 
 describe("TaskManager フィルター", () => {
   it("active フィルターは進行中・未着手のみを表示する", () => {
-    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
@@ -91,40 +91,40 @@ describe("TaskManager フィルター", () => {
   })
 
   it("todo フィルターは未着手のみを表示する", () => {
-    render(<TaskManager tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="todo" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("doing フィルターは進行中のみを表示する", () => {
-    render(<TaskManager tasks={tasks} currentFilter="doing" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="doing" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("未着手タスク")).not.toBeInTheDocument()
   })
 
   it("review フィルターは確認中のみを表示する", () => {
-    render(<TaskManager tasks={tasks} currentFilter="review" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="review" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("確認中タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("paused フィルターは一時中断のみを表示する", () => {
-    render(<TaskManager tasks={tasks} currentFilter="paused" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="paused" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("一時中断タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("all フィルターはすべてのタスクを表示する", () => {
-    render(<TaskManager tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(5)
   })
 
   it("不明なフィルターキーは active にフォールバックする", () => {
-    render(<TaskManager tasks={tasks} currentFilter="unknown-key" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="unknown-key" />)
     const panel = getCenterPanel()
     // active = 進行中・未着手
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
@@ -133,19 +133,19 @@ describe("TaskManager フィルター", () => {
   })
 
   it("タスク数を表示する", () => {
-    render(<TaskManager tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
     expect(within(getCenterPanel()).getByText("5 TASKS")).toBeInTheDocument()
   })
 
   it("フィルターに一致するタスクがない場合「タスクがありません」を表示する", () => {
     const noTasks = [makeTask({ status: "完了" })]
-    render(<TaskManager tasks={noTasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} tasks={noTasks} currentFilter="todo" />)
     expect(within(getCenterPanel()).getByText("— NO TASKS —")).toBeInTheDocument()
   })
 
   it("status が null のタスクは any ステータスフィルターにマッチしない", () => {
     const nullStatusTasks = [makeTask({ id: "n1", title: "ステータス不明", status: null })]
-    render(<TaskManager tasks={nullStatusTasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} tasks={nullStatusTasks} currentFilter="active" />)
     expect(within(getCenterPanel()).queryByText("ステータス不明")).not.toBeInTheDocument()
   })
 })
@@ -172,7 +172,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("左スワイプ 80px で active(0番) → todo(1番) に変わる", async () => {
-    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), -80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -181,7 +181,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("右スワイプ 80px で todo(1番) → active(0番) に戻る", async () => {
-    render(<TaskManager tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="todo" />)
     act(() => { swipe(getMain(), 80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -190,7 +190,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("左スワイプ @ all(末尾) → active(先頭) に循環する", async () => {
-    render(<TaskManager tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
     act(() => { swipe(getMain(), -80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -200,14 +200,14 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("右スワイプ @ active(先頭) → all(末尾) に循環する", async () => {
-    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), 80) })
     await act(async () => { vi.runAllTimers() })
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(5)
   })
 
   it("50px スワイプ（閾値未満）ではフィルターが変わらない", async () => {
-    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), -50) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -217,7 +217,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("縦スワイプ (dx=30, dy=200) ではフィルターが変わらない", async () => {
-    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), 30, 200) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -232,7 +232,7 @@ function getSearchInput() {
 
 describe("インクリメンタルサーチ", () => {
   it("タイトル部分一致で絞り込まれる", () => {
-    render(<TaskManager tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "進行中" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
@@ -246,7 +246,7 @@ describe("インクリメンタルサーチ", () => {
       makeTask({ id: "e1", title: "Refactor API", status: "進行中" }),
       makeTask({ id: "e2", title: "Write Tests", status: "未着手" }),
     ]
-    render(<TaskManager tasks={englishTasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} tasks={englishTasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "refactor" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("Refactor API")).toBeInTheDocument()
@@ -254,7 +254,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("空入力で全件に戻る", () => {
-    render(<TaskManager tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
     const input = getSearchInput()
     fireEvent.change(input, { target: { value: "進行中" } })
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(1)
@@ -263,7 +263,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("マッチが無いとき NO MATCH を表示する", () => {
-    render(<TaskManager tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "存在しない文字列" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("— NO MATCH —")).toBeInTheDocument()
@@ -271,7 +271,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("status フィルターと AND で組み合わさる", () => {
-    render(<TaskManager tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="todo" />)
     fireEvent.change(getSearchInput(), { target: { value: "タスク" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
@@ -281,7 +281,7 @@ describe("インクリメンタルサーチ", () => {
   it("swipe してフィルターが変わってもクエリは保持される", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout"] })
     try {
-      render(<TaskManager tasks={tasks} currentFilter="all" />)
+      render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
       fireEvent.change(getSearchInput(), { target: { value: "進行中" } })
       expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(1)
 
@@ -299,12 +299,12 @@ describe("インクリメンタルサーチ", () => {
 
 describe("ページネーションドット", () => {
   it("FILTERS の数だけドットが表示される", () => {
-    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
     expect(screen.getAllByRole("tab")).toHaveLength(FILTERS.length)
   })
 
   it("現在フィルターのドットが aria-selected=true、他は false", () => {
-    render(<TaskManager tasks={tasks} currentFilter="review" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="review" />)
     const dots = screen.getAllByRole("tab")
     const activeIdx = FILTERS.findIndex((f) => f.key === "review")
     dots.forEach((dot, i) => {
@@ -313,7 +313,7 @@ describe("ページネーションドット", () => {
   })
 
   it("ドットをクリックするとフィルターが変わる", async () => {
-    render(<TaskManager tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
     const allDot = screen.getByRole("tab", { name: "すべて" })
     await act(async () => { fireEvent.click(allDot) })
     await waitFor(() => {

--- a/src/lib/mock-tasks.ts
+++ b/src/lib/mock-tasks.ts
@@ -230,6 +230,10 @@ export function addMockTaskComment(id: string, text: string): TaskComment {
   return comment
 }
 
+export function getMockTagOptions(): string[] {
+  return ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
+}
+
 export function updateMockTask(id: string, input: UpdateTaskInput): Task | null {
   const idx = store.findIndex((t) => t.id === id)
   if (idx === -1) return null

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,10 +1,10 @@
 import { unstable_cache } from "next/cache"
 import { Client } from "@notionhq/client"
 import type { PageObjectResponse, BlockObjectResponse, PartialBlockObjectResponse, CommentObjectResponse } from "@notionhq/client/build/src/api-endpoints"
-import type { Task, TaskComment, TaskPriority, TaskStatus, TaskTag, CreateTaskInput, UpdateTaskInput } from "@/types/task"
+import type { Task, TaskComment, TaskPriority, TaskStatus, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 import { NOTION_PROPS } from "@/constants/notion"
 import { config } from "@/config"
-import { getMockTasks, getMockTask, createMockTask, updateMockTask, getMockTaskBlocks, updateMockTaskBlocks, getMockTaskComments, addMockTaskComment } from "@/lib/mock-tasks"
+import { getMockTasks, getMockTask, createMockTask, updateMockTask, getMockTaskBlocks, updateMockTaskBlocks, getMockTaskComments, addMockTaskComment, getMockTagOptions } from "@/lib/mock-tasks"
 
 function isDevMode() {
   return process.env.NODE_ENV === "development" || process.env.NEXTJS_ENV === "development"
@@ -43,9 +43,9 @@ function extractDueDate(props: PageObjectResponse["properties"]): string | null 
   return p?.date?.start ?? null
 }
 
-function extractTags(props: PageObjectResponse["properties"]): TaskTag[] {
+function extractTags(props: PageObjectResponse["properties"]): string[] {
   const p = props[NOTION_PROPS.TAG] as { type: "multi_select"; multi_select: Array<{ name: string }> }
-  return (p?.multi_select?.map((t) => t.name) ?? []) as TaskTag[]
+  return p?.multi_select?.map((t) => t.name) ?? []
 }
 
 function extractAssignees(props: PageObjectResponse["properties"]): string[] {
@@ -121,6 +121,20 @@ export function getTasks(options?: {
     ["tasks", statuses.join(",")],
     { tags: ["tasks"] }
   )()
+}
+
+export async function getTagOptions(): Promise<string[]> {
+  if (isDevMode()) return getMockTagOptions()
+  try {
+    const ds = await notion.dataSources.retrieve({ data_source_id: DATA_SOURCE_ID })
+    const tagProp = (ds as { properties: Record<string, unknown> }).properties?.[NOTION_PROPS.TAG] as
+      | { type: "multi_select"; multi_select: { options: Array<{ name: string }> } }
+      | undefined
+    return tagProp?.multi_select?.options?.map((o) => o.name) ?? []
+  } catch (e) {
+    console.error("[getTagOptions] Notion error:", e)
+    return []
+  }
 }
 
 export async function getTask(id: string): Promise<Task | null> {

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -9,14 +9,6 @@ export type TaskStatus =
 
 export type TaskPriority = "high" | "medium" | "low"
 
-export type TaskTag =
-  | "Network"
-  | "Blog"
-  | "Operation"
-  | "Finance"
-  | "Tech"
-  | "買い物🛍️"
-
 export type Task = {
   id: string
   url: string
@@ -24,7 +16,7 @@ export type Task = {
   status: TaskStatus | null
   priority: TaskPriority | null
   due: string | null
-  tags: TaskTag[]
+  tags: string[]
   assignees: string[]
   source: string | null
   sourceUrl: string | null
@@ -41,7 +33,7 @@ export type CreateTaskInput = {
   status?: TaskStatus
   priority?: TaskPriority
   due?: string | null
-  tags?: TaskTag[]
+  tags?: string[]
   body?: string
   source?: string
   sourceUrl?: string


### PR DESCRIPTION
## Summary
- ハードコードされた `TAG_OPTIONS` を削除し、Notion data source schema から `multi_select` の options を動的取得
- ページロード時に `getTasks()` と並列で `getTagOptions()` を呼び、props 経由で `TaskCreate` / `TaskDetail` へ伝搬
- 「常に最新」要件のためタグ取得はキャッシュしない（`getTasks()` の `unstable_cache` は維持）
- `TaskTag` 型を撤廃し `string[]` へ統一（Notion 側で追加されたタグも自動で UI に反映）

## Test plan
- [x] ユニットテスト 171/171 pass（`npm run test:unit`）
- [x] Playwright テスト 30/30 pass（`npx playwright test`）
- [x] Docker dev で `curl localhost:3000` SSR 出力にタグが含まれることを確認
- [ ] 本番デプロイ後、Notion 側でタグを追加 → ページリロードで新タグが選択肢に出ることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)