### PR TITLE
fix: タスク詳細の操作時に発生する違和感を解消

### DIFF
--- a/src/components/TaskCreate.tsx
+++ b/src/components/TaskCreate.tsx
@@ -175,7 +175,7 @@ export function TaskCreate({ tagOptions }: { tagOptions: string[] }) {
                       className="px-3 py-2 rounded-full text-xs transition-all"
                       style={
                         selectedTags.includes(tag)
-                          ? { backgroundColor: "#ff00cc", color: "#0d0014", boxShadow: "0 0 8px rgba(255,0,204,0.5)" }
+                          ? { backgroundColor: "#ff00cc", color: "#0d0014", border: "1px solid transparent", boxShadow: "0 0 8px rgba(255,0,204,0.5)" }
                           : { backgroundColor: "#0d0014", color: "#996688", border: "1px solid rgba(255,0,204,0.2)" }
                       }
                     >

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -9,7 +9,7 @@ import { parseDue, buildDue, snapTimeTo5Min, formatDueShort } from "@/lib/due-da
 import { DueDateTimeInput } from "./DueDateTimeInput"
 
 export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptions: string[]; onClose: () => void }) {
-  const [isPending, startTransition] = useTransition()
+  const [, startTransition] = useTransition()
   const [visible, setVisible] = useState(false)
 
   const [editTitle, setEditTitle] = useState(task.title)
@@ -298,8 +298,6 @@ export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptio
           backgroundColor: "#160022",
           borderTop: "1px solid rgba(255,0,204,0.5)",
           boxShadow: "0 -4px 30px rgba(255,0,204,0.2)",
-          opacity: isPending ? 0.85 : 1,
-          transition: "opacity 0.15s",
         }}
       >
         {/* Handle */}
@@ -378,7 +376,7 @@ export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptio
                   className="px-3 py-2 rounded-full text-xs transition-all"
                   style={
                     editTags.includes(tag)
-                      ? { backgroundColor: "#ff00cc", color: "#0d0014", boxShadow: "0 0 8px rgba(255,0,204,0.5)" }
+                      ? { backgroundColor: "#ff00cc", color: "#0d0014", border: "1px solid transparent", boxShadow: "0 0 8px rgba(255,0,204,0.5)" }
                       : { backgroundColor: "#0d0014", color: "#996688", border: "1px solid rgba(255,0,204,0.2)" }
                   }
                 >


### PR DESCRIPTION
## Summary
- タグの選択／未選択でボーダーの有無が変わってサイズが 2px ずれてレイアウトが揺れていたのを、選択済にも `1px solid transparent` を足して解消
- 保存中（`isPending`）にパネル全体が `opacity: 0.85` になり背後のタスク一覧が透けて見えていた挙動を削除。楽観的更新により各フィールドの値変更は即時画面に反映されるためフィードバックは維持される

## Test plan
- [x] ユニット 171/171 pass
- [x] Playwright 30/30 pass
- [ ] タスク詳細を開いてタグを連打しても並びが揺れないことを目視確認
- [ ] ステータス・優先度・期限・タグを変更してもパネル背景越しに一覧が透けないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)