### PR TITLE
feat: タスク一覧で 3 件目以降のタグを「+N」バッジで示す

### DIFF
--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -72,6 +72,11 @@ export function TaskItem({ task, onSelect }: { task: Task; onSelect: (id: string
             {tag}
           </span>
         ))}
+        {task.tags.length > 2 && (
+          <span className="text-xs text-[#553355] bg-[#160022] border border-[rgba(255,0,204,0.15)] px-2 py-1 rounded-full">
+            +{task.tags.length - 2}
+          </span>
+        )}
         {task.childTaskIds.length > 0 && (
           <span className="text-xs text-[#553355]">子{task.childTaskIds.length}件</span>
         )}

--- a/src/components/__tests__/TaskItem.test.tsx
+++ b/src/components/__tests__/TaskItem.test.tsx
@@ -104,13 +104,22 @@ describe("TaskItem レンダリング", () => {
     expect(screen.queryByText(/\d+月\d+日/)).not.toBeInTheDocument()
   })
 
-  it("タグを最大2件まで表示する", () => {
+  it("タグを最大2件まで表示し、3件目以降は +N バッジで示す", () => {
     render(
-      <TaskItem task={makeTask({ tags: ["Tech", "Blog", "Finance"] })} onSelect={vi.fn()} />
+      <TaskItem task={makeTask({ tags: ["Tech", "Blog", "Finance", "Network"] })} onSelect={vi.fn()} />
     )
     expect(screen.getByText("Tech")).toBeInTheDocument()
     expect(screen.getByText("Blog")).toBeInTheDocument()
     expect(screen.queryByText("Finance")).not.toBeInTheDocument()
+    expect(screen.queryByText("Network")).not.toBeInTheDocument()
+    expect(screen.getByText("+2")).toBeInTheDocument()
+  })
+
+  it("タグが 2 件以下のときは +N バッジを表示しない", () => {
+    render(
+      <TaskItem task={makeTask({ tags: ["Tech", "Blog"] })} onSelect={vi.fn()} />
+    )
+    expect(screen.queryByText(/^\+\d+$/)).not.toBeInTheDocument()
   })
 
   it("子タスク数を表示する", () => {


### PR DESCRIPTION
## Summary
- タスク一覧の各行は従来通り先頭 2 件のタグのみ表示し、3 件目以降は `+N` バッジで溢れを示す
- バッジは既存タグと同じピル形状で、色味だけ控えめに（区別しつつ視覚ノイズにしない）

## Test plan
- [x] ユニット 172/172 pass（既存「最大 2 件」テストを「2 件 + +N バッジ」に更新、2 件以下では出ないケースを追加）
- [x] Playwright 30/30 pass
- [ ] Notion で 3 タグ以上付いたタスクが一覧で「Tag1 Tag2 +N」と表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)