### PR TITLE
feat: タスク一覧にタグ／期限／優先度の複合フィルタを追加

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -5,7 +5,7 @@ import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { auth } from "@/auth"
 import { updateTask, createTask, getTaskBlocks, updateTaskBlocks, getTaskComments, createTaskComment, getTasks } from "@/lib/notion"
-import type { Task, TaskStatus, TaskComment, CreateTaskInput, UpdateTaskInput } from "@/types/task"
+import type { AdvancedFilter, Task, TaskStatus, TaskComment, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 import { getQueryStatuses } from "@/constants/filters"
 
 function isDevMode() {
@@ -21,6 +21,10 @@ async function requireAuth() {
 export async function setFilterAction(filter: string) {
   ;(await cookies()).set("filter", filter, { maxAge: 86400, path: "/" })
   revalidatePath("/")
+}
+
+export async function setAdvancedFilterAction(filter: AdvancedFilter) {
+  ;(await cookies()).set("filter_advanced", JSON.stringify(filter), { maxAge: 86400, path: "/" })
 }
 
 export async function fetchTasksByFilterAction(filterKey: string): Promise<Task[]> {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import { auth, signOut } from "@/auth"
 import { getTasks, getTagOptions } from "@/lib/notion"
 import { TaskManager } from "@/components/TaskManager"
 import { HydrationCheck } from "@/components/HydrationCheck"
-import { getQueryStatuses } from "@/constants/filters"
+import { getQueryStatuses, parseAdvancedFilter } from "@/constants/filters"
 
 export default async function Page({
   searchParams,
@@ -12,6 +12,13 @@ export default async function Page({
 }) {
   const cookieStore = await cookies()
   const filter = cookieStore.get("filter")?.value ?? "active"
+  const advancedRaw = cookieStore.get("filter_advanced")?.value
+  let advancedFilter
+  try {
+    advancedFilter = parseAdvancedFilter(advancedRaw ? JSON.parse(advancedRaw) : null)
+  } catch {
+    advancedFilter = parseAdvancedFilter(null)
+  }
   const { task: taskParam } = await searchParams
   const initialTaskId = typeof taskParam === "string" ? taskParam : null
 
@@ -43,7 +50,7 @@ export default async function Page({
       </header>
 
       <HydrationCheck />
-      <TaskManager tasks={tasks} tagOptions={tagOptions} currentFilter={filter} initialTaskId={initialTaskId} />
+      <TaskManager tasks={tasks} tagOptions={tagOptions} currentFilter={filter} initialAdvancedFilter={advancedFilter} initialTaskId={initialTaskId} />
     </div>
   )
 }

--- a/src/components/TaskFilterSheet.tsx
+++ b/src/components/TaskFilterSheet.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import type { AdvancedFilter, DueDateMode, TaskPriority } from "@/types/task"
+import { DEFAULT_ADVANCED_FILTER } from "@/constants/filters"
+import { PRIORITY_STYLES } from "@/constants/styles"
+
+const DUE_OPTIONS: { value: DueDateMode; label: string }[] = [
+  { value: "any",     label: "不問" },
+  { value: "with",    label: "あり" },
+  { value: "overdue", label: "期限切れ" },
+  { value: "without", label: "なし" },
+]
+
+const PRIORITY_OPTIONS: TaskPriority[] = ["high", "medium", "low"]
+
+export function TaskFilterSheet({
+  open,
+  filter,
+  tagOptions,
+  onApply,
+  onClose,
+}: {
+  open: boolean
+  filter: AdvancedFilter
+  tagOptions: string[]
+  onApply: (next: AdvancedFilter) => void
+  onClose: () => void
+}) {
+  const [draft, setDraft] = useState<AdvancedFilter>(filter)
+
+  // 開くたびに親の現状フィルタで draft を初期化
+  useEffect(() => {
+    if (open) setDraft(filter)
+  }, [open, filter])
+
+  function toggleTag(tag: string) {
+    setDraft((d) => ({
+      ...d,
+      tags: d.tags.includes(tag) ? d.tags.filter((t) => t !== tag) : [...d.tags, tag],
+    }))
+  }
+
+  function setDue(mode: DueDateMode) {
+    setDraft((d) => ({ ...d, dueDate: mode }))
+  }
+
+  function togglePriority(p: TaskPriority) {
+    setDraft((d) => ({
+      ...d,
+      priorities: d.priorities.includes(p) ? d.priorities.filter((x) => x !== p) : [...d.priorities, p],
+    }))
+  }
+
+  function handleReset() {
+    setDraft(DEFAULT_ADVANCED_FILTER)
+  }
+
+  function handleApply() {
+    onApply(draft)
+    onClose()
+  }
+
+  if (!open) return null
+
+  return (
+    <div data-testid="task-filter-sheet" className="fixed inset-0 z-50 flex flex-col justify-end">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose} />
+
+      <div
+        className="relative rounded-t-2xl px-5 pt-4 pb-10 safe-bottom max-h-[85svh] overflow-y-auto"
+        style={{
+          backgroundColor: "#160022",
+          borderTop: "1px solid rgba(255,0,204,0.5)",
+          boxShadow: "0 -4px 30px rgba(255,0,204,0.2)",
+        }}
+      >
+        <button onClick={onClose} className="w-full flex justify-center pb-2 -mt-1" aria-label="閉じる">
+          <div className="w-10 h-1 rounded-full" style={{ backgroundColor: "rgba(255,0,204,0.4)" }} />
+        </button>
+
+        <h2 className="text-sm text-[#ff00cc] tracking-widest uppercase mb-5 cyber-glow-text-sm">
+          ✦ Filters
+        </h2>
+
+        <div className="flex flex-col gap-5">
+          {/* タグ */}
+          <div>
+            <p className="text-xs text-[#996688] mb-2 tracking-widest uppercase">タグ</p>
+            {tagOptions.length === 0 ? (
+              <p className="text-xs text-[#553355] italic">タグがありません</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {tagOptions.map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => toggleTag(tag)}
+                    className="px-3 py-2 rounded-full text-xs transition-all"
+                    style={
+                      draft.tags.includes(tag)
+                        ? { backgroundColor: "#ff00cc", color: "#0d0014", border: "1px solid transparent", boxShadow: "0 0 8px rgba(255,0,204,0.5)" }
+                        : { backgroundColor: "#0d0014", color: "#996688", border: "1px solid rgba(255,0,204,0.2)" }
+                    }
+                  >
+                    {tag}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 期限 */}
+          <div>
+            <p className="text-xs text-[#996688] mb-2 tracking-widest uppercase">期限</p>
+            <div className="flex flex-wrap gap-2">
+              {DUE_OPTIONS.map((opt) => {
+                const active = draft.dueDate === opt.value
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    data-testid={`due-${opt.value}`}
+                    aria-pressed={active}
+                    onClick={() => setDue(opt.value)}
+                    className="px-3 py-2 rounded-full text-xs transition-all"
+                    style={
+                      active
+                        ? { backgroundColor: "#ff00cc", color: "#0d0014", border: "1px solid transparent", boxShadow: "0 0 8px rgba(255,0,204,0.5)" }
+                        : { backgroundColor: "#0d0014", color: "#996688", border: "1px solid rgba(255,0,204,0.2)" }
+                    }
+                  >
+                    {opt.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* 優先度 */}
+          <div>
+            <p className="text-xs text-[#996688] mb-2 tracking-widest uppercase">優先度</p>
+            <div className="flex flex-wrap gap-2">
+              {PRIORITY_OPTIONS.map((p) => {
+                const active = draft.priorities.includes(p)
+                return (
+                  <button
+                    key={p}
+                    type="button"
+                    data-testid={`priority-${p}`}
+                    onClick={() => togglePriority(p)}
+                    className="px-3 py-2 rounded-full text-xs transition-all"
+                    style={
+                      active
+                        ? { backgroundColor: "#ff00cc", color: "#0d0014", border: "1px solid transparent", boxShadow: "0 0 8px rgba(255,0,204,0.5)" }
+                        : { backgroundColor: "#0d0014", color: "#996688", border: "1px solid rgba(255,0,204,0.2)" }
+                    }
+                  >
+                    {PRIORITY_STYLES[p].label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-3 mt-8">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="flex-1 rounded-xl py-3 text-xs text-[#996688] hover:text-[#ffbbee] transition-colors tracking-widest uppercase"
+            style={{ border: "1px solid rgba(255,0,204,0.25)" }}
+          >
+            リセット
+          </button>
+          <button
+            type="button"
+            onClick={handleApply}
+            className="flex-[2] rounded-xl py-3 text-sm tracking-widest uppercase"
+            style={{
+              backgroundColor: "#ff00cc",
+              color: "#0d0014",
+              boxShadow: "0 0 12px rgba(255,0,204,0.5), 0 0 30px rgba(255,0,204,0.2)",
+            }}
+          >
+            適用
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,12 +1,13 @@
 "use client"
 
 import { useState, useTransition, useEffect, useRef, useMemo } from "react"
-import type { Task } from "@/types/task"
+import type { AdvancedFilter, Task } from "@/types/task"
 import { TaskItem } from "./TaskItem"
 import { TaskDetail } from "./TaskDetail"
 import { TaskCreate } from "./TaskCreate"
-import { setFilterAction, refreshTasksAction, fetchTasksByFilterAction } from "@/app/actions"
-import { FILTERS } from "@/constants/filters"
+import { TaskFilterSheet } from "./TaskFilterSheet"
+import { setFilterAction, setAdvancedFilterAction, refreshTasksAction, fetchTasksByFilterAction } from "@/app/actions"
+import { FILTERS, applyAdvancedFilter, isAdvancedFilterActive } from "@/constants/filters"
 import { sortByPriorityAndDue, groupAndSort } from "@/lib/task-sort"
 
 // ─── TaskListPanel ─────────────────────────────────────────────────────────────
@@ -34,11 +35,13 @@ function TaskListPanel({
   filterKey,
   tasks,
   searchQuery,
+  advancedFilter,
   onSelect,
 }: {
   filterKey: string
   tasks: Task[] | undefined
   searchQuery: string
+  advancedFilter: AdvancedFilter
   onSelect: (id: string) => void
 }) {
   const current = FILTERS.find((f) => f.key === filterKey) ?? FILTERS[0]
@@ -48,8 +51,9 @@ function TaskListPanel({
     const byStatus = current.statuses
       ? (tasks ?? []).filter((t) => t.status && current.statuses!.includes(t.status))
       : (tasks ?? [])
-    return q === "" ? byStatus : byStatus.filter((t) => t.title.toLowerCase().includes(q))
-  }, [tasks, current.statuses, q])
+    const byAdvanced = applyAdvancedFilter(byStatus, advancedFilter)
+    return q === "" ? byAdvanced : byAdvanced.filter((t) => t.title.toLowerCase().includes(q))
+  }, [tasks, current.statuses, q, advancedFilter])
 
   const isGrouped = !current.statuses || current.statuses.length > 1
   const groups = isGrouped ? groupAndSort(filtered) : null
@@ -111,13 +115,18 @@ export function TaskManager({
   tasks,
   tagOptions,
   currentFilter,
+  initialAdvancedFilter,
   initialTaskId,
 }: {
   tasks: Task[]
   tagOptions: string[]
   currentFilter: string
+  initialAdvancedFilter: AdvancedFilter
   initialTaskId?: string | null
 }) {
+  const [advancedFilter, setAdvancedFilter] = useState<AdvancedFilter>(initialAdvancedFilter)
+  const [filterSheetOpen, setFilterSheetOpen] = useState(false)
+  const advancedActive = isAdvancedFilterActive(advancedFilter)
   const [isPending, startTransition] = useTransition()
   const [completingBar, setCompletingBar] = useState(false)
   const prevIsPendingRef = useRef(isPending)
@@ -344,16 +353,45 @@ export function TaskManager({
           </button>
         </div>
 
-        <input
-          data-testid="search-input"
-          type="search"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder="検索..."
-          aria-label="タスクを検索"
-          className="w-full rounded-xl px-4 py-3 text-sm bg-[#160022] text-[#ffbbee] placeholder:text-[#553355] border border-[rgba(255,0,204,0.3)] focus:outline-none focus:border-[#ff00cc]"
-          style={{ transition: "border-color 0.2s" }}
-        />
+        <div className="flex gap-2">
+          <input
+            data-testid="search-input"
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="検索..."
+            aria-label="タスクを検索"
+            className="flex-1 rounded-xl px-4 py-3 text-sm bg-[#160022] text-[#ffbbee] placeholder:text-[#553355] border border-[rgba(255,0,204,0.3)] focus:outline-none focus:border-[#ff00cc]"
+            style={{ transition: "border-color 0.2s" }}
+          />
+          <button
+            data-testid="filter-button"
+            aria-label="フィルタを開く"
+            onClick={() => setFilterSheetOpen(true)}
+            className="relative flex-shrink-0 w-10 self-stretch rounded-xl border border-[rgba(255,0,204,0.3)] bg-[#160022] text-[#ff00cc] flex items-center justify-center hover:border-[#ff00cc] active:scale-95 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+            </svg>
+            {advancedActive && (
+              <span
+                data-testid="filter-active-dot"
+                className="absolute top-1 right-1 w-2 h-2 rounded-full"
+                style={{ backgroundColor: "#ff00cc", boxShadow: "0 0 6px rgba(255,0,204,0.7)" }}
+              />
+            )}
+          </button>
+        </div>
 
         {/* ページネーションドット */}
         <div className="flex justify-center items-center gap-2">
@@ -400,21 +438,21 @@ export function TaskManager({
           {/* 左パネル（前フィルター） */}
           <div style={{ width: "33.333%", height: "100%", overflowY: "auto" }}>
             <div className="max-w-2xl mx-auto">
-              <TaskListPanel filterKey={left} tasks={taskCache.get(left)} searchQuery={searchQuery} onSelect={setSelectedTaskId} />
+              <TaskListPanel filterKey={left} tasks={taskCache.get(left)} searchQuery={searchQuery} advancedFilter={advancedFilter} onSelect={setSelectedTaskId} />
             </div>
           </div>
 
           {/* 中央パネル（現在フィルター） */}
           <div data-testid="panel-center" style={{ width: "33.333%", height: "100%", overflowY: "auto" }}>
             <div className="max-w-2xl mx-auto">
-              <TaskListPanel filterKey={center} tasks={taskCache.get(center)} searchQuery={searchQuery} onSelect={setSelectedTaskId} />
+              <TaskListPanel filterKey={center} tasks={taskCache.get(center)} searchQuery={searchQuery} advancedFilter={advancedFilter} onSelect={setSelectedTaskId} />
             </div>
           </div>
 
           {/* 右パネル（次フィルター） */}
           <div style={{ width: "33.333%", height: "100%", overflowY: "auto" }}>
             <div className="max-w-2xl mx-auto">
-              <TaskListPanel filterKey={right} tasks={taskCache.get(right)} searchQuery={searchQuery} onSelect={setSelectedTaskId} />
+              <TaskListPanel filterKey={right} tasks={taskCache.get(right)} searchQuery={searchQuery} advancedFilter={advancedFilter} onSelect={setSelectedTaskId} />
             </div>
           </div>
         </div>
@@ -424,6 +462,16 @@ export function TaskManager({
       {selectedTask && (
         <TaskDetail task={selectedTask} tagOptions={tagOptions} onClose={() => setSelectedTaskId(null)} />
       )}
+      <TaskFilterSheet
+        open={filterSheetOpen}
+        filter={advancedFilter}
+        tagOptions={tagOptions}
+        onApply={(next) => {
+          setAdvancedFilter(next)
+          startTransition(async () => { await setAdvancedFilterAction(next) })
+        }}
+        onClose={() => setFilterSheetOpen(false)}
+      />
     </div>
   )
 }

--- a/src/components/__tests__/TaskFilterSheet.test.tsx
+++ b/src/components/__tests__/TaskFilterSheet.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { TaskFilterSheet } from "@/components/TaskFilterSheet"
+import { DEFAULT_ADVANCED_FILTER } from "@/constants/filters"
+
+const TAGS = ["Tech", "Blog", "Operation"]
+
+describe("TaskFilterSheet 表示", () => {
+  it("open=false のとき何もレンダリングしない", () => {
+    const { container } = render(
+      <TaskFilterSheet
+        open={false}
+        filter={DEFAULT_ADVANCED_FILTER}
+        tagOptions={TAGS}
+        onApply={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("open=true のとき各セクションが表示される", () => {
+    render(
+      <TaskFilterSheet
+        open={true}
+        filter={DEFAULT_ADVANCED_FILTER}
+        tagOptions={TAGS}
+        onApply={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("タグ")).toBeInTheDocument()
+    expect(screen.getByText("期限")).toBeInTheDocument()
+    expect(screen.getByText("優先度")).toBeInTheDocument()
+    for (const tag of TAGS) {
+      expect(screen.getByRole("button", { name: tag })).toBeInTheDocument()
+    }
+  })
+
+  it("tagOptions が空のとき「タグがありません」と表示", () => {
+    render(
+      <TaskFilterSheet open={true} filter={DEFAULT_ADVANCED_FILTER} tagOptions={[]} onApply={vi.fn()} onClose={vi.fn()} />,
+    )
+    expect(screen.getByText("タグがありません")).toBeInTheDocument()
+  })
+})
+
+describe("TaskFilterSheet 操作", () => {
+  function setup(filter = DEFAULT_ADVANCED_FILTER) {
+    const onApply = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <TaskFilterSheet open={true} filter={filter} tagOptions={TAGS} onApply={onApply} onClose={onClose} />,
+    )
+    return { onApply, onClose }
+  }
+
+  it("タグをクリック→適用で onApply が選択タグ付きで呼ばれる", () => {
+    const { onApply } = setup()
+    fireEvent.click(screen.getByRole("button", { name: "Tech" }))
+    fireEvent.click(screen.getByRole("button", { name: "Blog" }))
+    fireEvent.click(screen.getByRole("button", { name: "適用" }))
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ tags: ["Tech", "Blog"] }))
+  })
+
+  it("期限を期限切れに変更→適用", () => {
+    const { onApply } = setup()
+    fireEvent.click(screen.getByTestId("due-overdue"))
+    fireEvent.click(screen.getByRole("button", { name: "適用" }))
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ dueDate: "overdue" }))
+  })
+
+  it("優先度を高だけ選択→適用", () => {
+    const { onApply } = setup()
+    fireEvent.click(screen.getByTestId("priority-high"))
+    fireEvent.click(screen.getByRole("button", { name: "適用" }))
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ priorities: ["high"] }))
+  })
+
+  it("リセットで draft がデフォルトに戻る（適用前）", () => {
+    const { onApply } = setup({ tags: ["Tech"], dueDate: "with", priorities: ["high"] })
+    fireEvent.click(screen.getByRole("button", { name: "リセット" }))
+    fireEvent.click(screen.getByRole("button", { name: "適用" }))
+    expect(onApply).toHaveBeenCalledWith(DEFAULT_ADVANCED_FILTER)
+  })
+
+  it("適用すると onClose も呼ばれる", () => {
+    const { onClose } = setup()
+    fireEvent.click(screen.getByRole("button", { name: "適用" }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("バックドロップクリックで onClose、適用前なので onApply は呼ばれない", () => {
+    const { onApply, onClose } = setup()
+    fireEvent.click(screen.getByRole("button", { name: "Tech" }))
+    const backdrop = document.querySelector('[class*="bg-black"]') as HTMLElement
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalled()
+    expect(onApply).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -6,6 +6,7 @@ import type { Task } from "@/types/task"
 
 vi.mock("@/app/actions", () => ({
   setFilterAction: vi.fn().mockResolvedValue(undefined),
+  setAdvancedFilterAction: vi.fn().mockResolvedValue(undefined),
   refreshTasksAction: vi.fn().mockResolvedValue(undefined),
   fetchTasksByFilterAction: vi.fn().mockResolvedValue([]),
 }))
@@ -81,7 +82,7 @@ afterEach(() => {
 
 describe("TaskManager フィルター", () => {
   it("active フィルターは進行中・未着手のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
@@ -91,40 +92,40 @@ describe("TaskManager フィルター", () => {
   })
 
   it("todo フィルターは未着手のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="todo" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("doing フィルターは進行中のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="doing" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="doing" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("未着手タスク")).not.toBeInTheDocument()
   })
 
   it("review フィルターは確認中のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="review" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="review" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("確認中タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("paused フィルターは一時中断のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="paused" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="paused" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("一時中断タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("all フィルターはすべてのタスクを表示する", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(5)
   })
 
   it("不明なフィルターキーは active にフォールバックする", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="unknown-key" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="unknown-key" />)
     const panel = getCenterPanel()
     // active = 進行中・未着手
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
@@ -133,19 +134,19 @@ describe("TaskManager フィルター", () => {
   })
 
   it("タスク数を表示する", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
     expect(within(getCenterPanel()).getByText("5 TASKS")).toBeInTheDocument()
   })
 
   it("フィルターに一致するタスクがない場合「タスクがありません」を表示する", () => {
     const noTasks = [makeTask({ status: "完了" })]
-    render(<TaskManager tagOptions={[]} tasks={noTasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={noTasks} currentFilter="todo" />)
     expect(within(getCenterPanel()).getByText("— NO TASKS —")).toBeInTheDocument()
   })
 
   it("status が null のタスクは any ステータスフィルターにマッチしない", () => {
     const nullStatusTasks = [makeTask({ id: "n1", title: "ステータス不明", status: null })]
-    render(<TaskManager tagOptions={[]} tasks={nullStatusTasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={nullStatusTasks} currentFilter="active" />)
     expect(within(getCenterPanel()).queryByText("ステータス不明")).not.toBeInTheDocument()
   })
 })
@@ -172,7 +173,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("左スワイプ 80px で active(0番) → todo(1番) に変わる", async () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), -80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -181,7 +182,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("右スワイプ 80px で todo(1番) → active(0番) に戻る", async () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="todo" />)
     act(() => { swipe(getMain(), 80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -190,7 +191,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("左スワイプ @ all(末尾) → active(先頭) に循環する", async () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
     act(() => { swipe(getMain(), -80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -200,14 +201,14 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("右スワイプ @ active(先頭) → all(末尾) に循環する", async () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), 80) })
     await act(async () => { vi.runAllTimers() })
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(5)
   })
 
   it("50px スワイプ（閾値未満）ではフィルターが変わらない", async () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), -50) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -217,7 +218,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("縦スワイプ (dx=30, dy=200) ではフィルターが変わらない", async () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), 30, 200) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -232,7 +233,7 @@ function getSearchInput() {
 
 describe("インクリメンタルサーチ", () => {
   it("タイトル部分一致で絞り込まれる", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "進行中" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
@@ -246,7 +247,7 @@ describe("インクリメンタルサーチ", () => {
       makeTask({ id: "e1", title: "Refactor API", status: "進行中" }),
       makeTask({ id: "e2", title: "Write Tests", status: "未着手" }),
     ]
-    render(<TaskManager tagOptions={[]} tasks={englishTasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={englishTasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "refactor" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("Refactor API")).toBeInTheDocument()
@@ -254,7 +255,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("空入力で全件に戻る", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
     const input = getSearchInput()
     fireEvent.change(input, { target: { value: "進行中" } })
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(1)
@@ -263,7 +264,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("マッチが無いとき NO MATCH を表示する", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "存在しない文字列" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("— NO MATCH —")).toBeInTheDocument()
@@ -271,7 +272,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("status フィルターと AND で組み合わさる", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="todo" />)
     fireEvent.change(getSearchInput(), { target: { value: "タスク" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
@@ -281,7 +282,7 @@ describe("インクリメンタルサーチ", () => {
   it("swipe してフィルターが変わってもクエリは保持される", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout"] })
     try {
-      render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="all" />)
+      render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
       fireEvent.change(getSearchInput(), { target: { value: "進行中" } })
       expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(1)
 
@@ -299,12 +300,12 @@ describe("インクリメンタルサーチ", () => {
 
 describe("ページネーションドット", () => {
   it("FILTERS の数だけドットが表示される", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
     expect(screen.getAllByRole("tab")).toHaveLength(FILTERS.length)
   })
 
   it("現在フィルターのドットが aria-selected=true、他は false", () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="review" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="review" />)
     const dots = screen.getAllByRole("tab")
     const activeIdx = FILTERS.findIndex((f) => f.key === "review")
     dots.forEach((dot, i) => {
@@ -313,7 +314,7 @@ describe("ページネーションドット", () => {
   })
 
   it("ドットをクリックするとフィルターが変わる", async () => {
-    render(<TaskManager tagOptions={[]} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
     const allDot = screen.getByRole("tab", { name: "すべて" })
     await act(async () => { fireEvent.click(allDot) })
     await waitFor(() => {

--- a/src/constants/__tests__/filters.test.ts
+++ b/src/constants/__tests__/filters.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest"
+import type { AdvancedFilter, Task } from "@/types/task"
+import { applyAdvancedFilter, isAdvancedFilterActive, parseAdvancedFilter, DEFAULT_ADVANCED_FILTER } from "@/constants/filters"
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t",
+    url: "https://notion.so/t",
+    title: "title",
+    status: "未着手",
+    priority: null,
+    due: null,
+    tags: [],
+    assignees: [],
+    source: null,
+    sourceUrl: null,
+    parentTaskIds: [],
+    childTaskIds: [],
+    prevTaskIds: [],
+    nextTaskIds: [],
+    createdTime: "2024-01-01T00:00:00.000Z",
+    lastEditedTime: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+const NONE: AdvancedFilter = DEFAULT_ADVANCED_FILTER
+
+describe("applyAdvancedFilter — タグ OR", () => {
+  const tasks = [
+    makeTask({ id: "1", tags: ["Tech"] }),
+    makeTask({ id: "2", tags: ["Blog"] }),
+    makeTask({ id: "3", tags: ["Tech", "Blog"] }),
+    makeTask({ id: "4", tags: [] }),
+  ]
+
+  it("単一タグの選択でそのタグを持つタスクが残る", () => {
+    const result = applyAdvancedFilter(tasks, { ...NONE, tags: ["Tech"] })
+    expect(result.map((t) => t.id)).toEqual(["1", "3"])
+  })
+
+  it("複数タグは OR で結合される", () => {
+    const result = applyAdvancedFilter(tasks, { ...NONE, tags: ["Tech", "Blog"] })
+    expect(result.map((t) => t.id)).toEqual(["1", "2", "3"])
+  })
+
+  it("タグ空配列はフィルタ非適用", () => {
+    expect(applyAdvancedFilter(tasks, NONE)).toHaveLength(4)
+  })
+})
+
+describe("applyAdvancedFilter — 期限", () => {
+  const past = "2000-01-01"
+  const future = new Date(Date.now() + 86400_000 * 30).toISOString()
+  const tasks = [
+    makeTask({ id: "p", due: past }),
+    makeTask({ id: "f", due: future }),
+    makeTask({ id: "n", due: null }),
+  ]
+
+  it("any はすべて返す", () => {
+    expect(applyAdvancedFilter(tasks, { ...NONE, dueDate: "any" })).toHaveLength(3)
+  })
+  it("with は due ありのみ", () => {
+    expect(applyAdvancedFilter(tasks, { ...NONE, dueDate: "with" }).map((t) => t.id)).toEqual(["p", "f"])
+  })
+  it("without は due なしのみ", () => {
+    expect(applyAdvancedFilter(tasks, { ...NONE, dueDate: "without" }).map((t) => t.id)).toEqual(["n"])
+  })
+  it("overdue は過去 due のみ", () => {
+    expect(applyAdvancedFilter(tasks, { ...NONE, dueDate: "overdue" }).map((t) => t.id)).toEqual(["p"])
+  })
+})
+
+describe("applyAdvancedFilter — 優先度 OR", () => {
+  const tasks = [
+    makeTask({ id: "h", priority: "high" }),
+    makeTask({ id: "m", priority: "medium" }),
+    makeTask({ id: "l", priority: "low" }),
+    makeTask({ id: "z", priority: null }),
+  ]
+
+  it("空配列はフィルタ非適用", () => {
+    expect(applyAdvancedFilter(tasks, NONE)).toHaveLength(4)
+  })
+  it("単一の優先度", () => {
+    expect(applyAdvancedFilter(tasks, { ...NONE, priorities: ["high"] }).map((t) => t.id)).toEqual(["h"])
+  })
+  it("複数の優先度は OR", () => {
+    expect(applyAdvancedFilter(tasks, { ...NONE, priorities: ["high", "low"] }).map((t) => t.id)).toEqual(["h", "l"])
+  })
+  it("priority が null のタスクは優先度フィルタ指定時に除外される", () => {
+    const result = applyAdvancedFilter(tasks, { ...NONE, priorities: ["high", "medium", "low"] })
+    expect(result.map((t) => t.id)).not.toContain("z")
+  })
+})
+
+describe("applyAdvancedFilter — 複合 AND", () => {
+  it("タグ・期限・優先度の組合せが AND で適用される", () => {
+    const tasks = [
+      makeTask({ id: "1", tags: ["Tech"], priority: "high",   due: "2026-12-31" }),
+      makeTask({ id: "2", tags: ["Tech"], priority: "low",    due: "2026-12-31" }),
+      makeTask({ id: "3", tags: ["Blog"], priority: "high",   due: null         }),
+      makeTask({ id: "4", tags: ["Tech"], priority: "high",   due: null         }),
+    ]
+    const result = applyAdvancedFilter(tasks, {
+      tags: ["Tech"],
+      dueDate: "with",
+      priorities: ["high"],
+    })
+    expect(result.map((t) => t.id)).toEqual(["1"])
+  })
+})
+
+describe("isAdvancedFilterActive", () => {
+  it("デフォルトは false", () => {
+    expect(isAdvancedFilterActive(DEFAULT_ADVANCED_FILTER)).toBe(false)
+  })
+  it("タグが入っていれば true", () => {
+    expect(isAdvancedFilterActive({ ...DEFAULT_ADVANCED_FILTER, tags: ["X"] })).toBe(true)
+  })
+  it("期限がデフォルト以外なら true", () => {
+    expect(isAdvancedFilterActive({ ...DEFAULT_ADVANCED_FILTER, dueDate: "with" })).toBe(true)
+  })
+  it("優先度が入っていれば true", () => {
+    expect(isAdvancedFilterActive({ ...DEFAULT_ADVANCED_FILTER, priorities: ["high"] })).toBe(true)
+  })
+})
+
+describe("parseAdvancedFilter — 型ガード", () => {
+  it("null/undefined はデフォルト", () => {
+    expect(parseAdvancedFilter(null)).toEqual(DEFAULT_ADVANCED_FILTER)
+    expect(parseAdvancedFilter(undefined)).toEqual(DEFAULT_ADVANCED_FILTER)
+  })
+  it("不正な dueDate はデフォルトの any にフォールバック", () => {
+    expect(parseAdvancedFilter({ tags: [], dueDate: "garbage", priorities: [] }).dueDate).toBe("any")
+  })
+  it("不正な優先度値は除外される", () => {
+    const result = parseAdvancedFilter({ tags: ["X"], dueDate: "with", priorities: ["high", "garbage"] })
+    expect(result.priorities).toEqual(["high"])
+    expect(result.tags).toEqual(["X"])
+    expect(result.dueDate).toBe("with")
+  })
+  it("string 以外のタグは除外される", () => {
+    const result = parseAdvancedFilter({ tags: ["A", 42, null, "B"], dueDate: "any", priorities: [] })
+    expect(result.tags).toEqual(["A", "B"])
+  })
+  it("tags が配列でなければ空配列", () => {
+    expect(parseAdvancedFilter({ tags: "not-array", dueDate: "any", priorities: [] }).tags).toEqual([])
+  })
+})

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -1,4 +1,5 @@
-import type { TaskStatus } from "@/types/task"
+import type { AdvancedFilter, DueDateMode, Task, TaskPriority, TaskStatus } from "@/types/task"
+import { isOverdue } from "@/lib/due-date"
 
 export const FILTERS: { label: string; key: string; statuses: TaskStatus[] | null }[] = [
   { label: "進行中・未着手", key: "active", statuses: ["進行中", "未着手"] },
@@ -15,4 +16,47 @@ const ALL_STATUSES: TaskStatus[] = ["未着手", "進行中", "確認中", "一�
 export function getQueryStatuses(filterKey: string): TaskStatus[] {
   const filter = FILTERS.find((f) => f.key === filterKey) ?? FILTERS[0]
   return filter.statuses ?? ALL_STATUSES
+}
+
+export const DEFAULT_ADVANCED_FILTER: AdvancedFilter = {
+  tags: [],
+  dueDate: "any",
+  priorities: [],
+}
+
+const DUE_MODES: readonly DueDateMode[] = ["any", "with", "overdue", "without"]
+const PRIORITIES: readonly TaskPriority[] = ["high", "medium", "low"]
+
+/** 不正値や古いスキーマで落ちないよう各フィールドを検証 */
+export function parseAdvancedFilter(raw: unknown): AdvancedFilter {
+  if (!raw || typeof raw !== "object") return DEFAULT_ADVANCED_FILTER
+  const obj = raw as Record<string, unknown>
+  const tags = Array.isArray(obj.tags) ? obj.tags.filter((t): t is string => typeof t === "string") : []
+  const dueDate = DUE_MODES.includes(obj.dueDate as DueDateMode) ? (obj.dueDate as DueDateMode) : "any"
+  const priorities = Array.isArray(obj.priorities)
+    ? obj.priorities.filter((p): p is TaskPriority => PRIORITIES.includes(p as TaskPriority))
+    : []
+  return { tags, dueDate, priorities }
+}
+
+/** デフォルトと差分があるか（インジケータ表示用） */
+export function isAdvancedFilterActive(filter: AdvancedFilter): boolean {
+  return filter.tags.length > 0 || filter.dueDate !== "any" || filter.priorities.length > 0
+}
+
+/** ステータスでフィルタ済みのタスク配列に、追加次元（タグ/期限/優先度）を AND で重畳する */
+export function applyAdvancedFilter(tasks: Task[], filter: AdvancedFilter): Task[] {
+  return tasks.filter((task) => {
+    if (filter.tags.length > 0 && !filter.tags.some((t) => task.tags.includes(t))) return false
+
+    if (filter.dueDate === "with" && !task.due) return false
+    if (filter.dueDate === "without" && task.due) return false
+    if (filter.dueDate === "overdue" && !isOverdue(task.due)) return false
+
+    if (filter.priorities.length > 0) {
+      if (!task.priority || !filter.priorities.includes(task.priority)) return false
+    }
+
+    return true
+  })
 }

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -48,3 +48,11 @@ export type TaskComment = {
   author: string
   createdTime: string
 }
+
+export type DueDateMode = "any" | "with" | "overdue" | "without"
+
+export type AdvancedFilter = {
+  tags: string[]
+  dueDate: DueDateMode
+  priorities: TaskPriority[]
+}


### PR DESCRIPTION
## Summary
- 検索の右にフィルタアイコンボタンを設置、タップでボトムシートを開く
- ボトムシートで以下を選択：
  - **タグ**: `tagOptions` から複数選択（OR 検索）
  - **期限**: 不問 / あり / 期限切れのみ / なし の 4 択（矛盾しない統合形式）
  - **優先度**: high / medium / low の複数選択
- 新フィルタはステータスフィルタ（既存・サーバ側）にクライアント側で AND 重畳。カルーセルやプリフェッチには影響なし
- 状態は `filter_advanced` Cookie（24h, JSON）で永続化。リロード／タブ復帰でも維持
- ボタン右上のドットでフィルタアクティブを示すインジケータ

## Test plan
- [x] ユニット 202/202 pass（applyAdvancedFilter 全ケース、parseAdvancedFilter 型ガード、TaskFilterSheet 操作、TaskManager 既存テストの prop 追加）
- [x] TypeScript typecheck pass
- [x] Playwright 30/30 pass（既存テスト）
- [ ] フィルタボタン → ボトムシート → タグ／期限／優先度を選び「適用」で一覧が絞り込まれる
- [ ] リロード後もフィルタ状態が維持される
- [ ] 「リセット」→「適用」で初期状態に戻る／インジケータドットが消える
- [ ] ステータスのスワイプ／カルーセルがフィルタと干渉せず、各パネルにフィルタが反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)