### PR TITLE
fix: タスク詳細でNotion画像を表示し、本文編集時も保持する

### DIFF
--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -64,6 +64,22 @@ export function MarkdownPreview({ content, onToggleCheckbox }: { content: string
       return
     }
 
+    const imgMatch = line.match(/^!\[([^\]]*)\]\((.+)\)$/)
+    if (imgMatch) {
+      const [, alt, src] = imgMatch
+      elements.push(
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          key={i}
+          src={src}
+          alt={alt}
+          className="my-2 max-w-full rounded-lg"
+          style={{ border: "1px solid rgba(255,0,204,0.2)" }}
+        />
+      )
+      return
+    }
+
     if (line === "---") {
       elements.push(<hr key={i} className="my-2 border-[rgba(255,0,204,0.2)]" />)
     } else if (line.startsWith("# ")) {

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -216,7 +216,10 @@ export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptio
 
     try {
       await updateTaskBlocksAction(task.id, editBlocksContent)
-      setBlocks(editBlocksContent)
+      // Re-fetch: saved markdown drops image lines, but Notion still has the
+      // image blocks. Re-read so the preview reflects the real state.
+      const refreshed = await getTaskBlocksAction(task.id)
+      setBlocks(refreshed)
       setIsEditingBlocks(false)
     } catch {
       setBlocksSaveError("本文の保存に失敗しました。")

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -321,7 +321,9 @@ describe("TaskDetail 本文編集", () => {
 
   it("編集して保存すると updateTaskBlocksAction が呼ばれる", async () => {
     const updateBlocksMock = vi.mocked(updateTaskBlocksAction)
-    vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("元の本文")
+    vi.mocked(getTaskBlocksAction)
+      .mockResolvedValueOnce("元の本文")
+      .mockResolvedValueOnce("更新後の本文")
 
     render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
 
@@ -337,6 +339,26 @@ describe("TaskDetail 本文編集", () => {
     })
 
     expect(await screen.findByText("更新後の本文")).toBeInTheDocument()
+  })
+
+  it("画像付き本文を編集・保存しても画像が再フェッチで戻る", async () => {
+    vi.mocked(getTaskBlocksAction)
+      .mockResolvedValueOnce("元の本文\n![プレビュー](https://example.com/img.png)")
+      // 保存後の再フェッチ：Notion 側に画像は残ったまま、テキストだけ更新された状態を返す
+      .mockResolvedValueOnce("更新後の本文\n![プレビュー](https://example.com/img.png)")
+
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
+
+    expect(await screen.findByRole("img", { name: "プレビュー" })).toHaveAttribute("src", "https://example.com/img.png")
+
+    fireEvent.click(screen.getByRole("button", { name: "編集" }))
+    fireEvent.change(screen.getByPlaceholderText("Markdownで入力（# 見出し、- リスト など）"), {
+      target: { value: "更新後の本文\n![プレビュー](https://example.com/img.png)" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "保存" }))
+
+    expect(await screen.findByText("更新後の本文")).toBeInTheDocument()
+    expect(await screen.findByRole("img", { name: "プレビュー" })).toHaveAttribute("src", "https://example.com/img.png")
   })
 
   it("本文中の URL がクリッカブルリンクになる", async () => {
@@ -366,6 +388,15 @@ describe("TaskDetail 本文編集", () => {
 
     const link = await screen.findByRole("link", { name: "https://example.com" })
     expect(link).toHaveAttribute("href", "https://example.com")
+  })
+
+  it("本文中の画像 markdown を img として描画する", async () => {
+    vi.mocked(getTaskBlocksAction).mockResolvedValueOnce("![スクショ](https://example.com/img.png)")
+
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
+
+    const img = await screen.findByRole("img", { name: "スクショ" })
+    expect(img).toHaveAttribute("src", "https://example.com/img.png")
   })
 
   it("本文取得に失敗してもローディングから復帰する", async () => {

--- a/src/lib/__tests__/notion.test.ts
+++ b/src/lib/__tests__/notion.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints"
 
 // vi.hoisted でモジュール読み込み前にモックを定義
-const { mockPages, mockDataSources } = vi.hoisted(() => ({
+const { mockPages, mockDataSources, mockBlocks } = vi.hoisted(() => ({
   mockPages: {
     retrieve: vi.fn(),
     create: vi.fn(),
@@ -10,6 +10,10 @@ const { mockPages, mockDataSources } = vi.hoisted(() => ({
   },
   mockDataSources: {
     query: vi.fn(),
+  },
+  mockBlocks: {
+    children: { list: vi.fn(), append: vi.fn() },
+    delete: vi.fn(),
   },
 }))
 
@@ -21,11 +25,11 @@ vi.mock("next/cache", () => ({
 vi.mock("@notionhq/client", () => ({
   // new Client() が呼び出されるため通常の function が必要
   Client: vi.fn(function () {
-    return { pages: mockPages, dataSources: mockDataSources }
+    return { pages: mockPages, dataSources: mockDataSources, blocks: mockBlocks }
   }),
 }))
 
-import { getTask, getTasks, createTask, updateTask } from "@/lib/notion"
+import { getTask, getTasks, createTask, updateTask, getTaskBlocks, updateTaskBlocks } from "@/lib/notion"
 
 // テスト用の Notion ページレスポンスを組み立てるヘルパー
 function makePage(overrides: {
@@ -452,5 +456,145 @@ describe("updateTask", () => {
     const props = mockPages.update.mock.calls[0][0].properties
     expect(props["タイトル"]).toBeUndefined()
     expect(props["Priority"]).toBeUndefined()
+  })
+})
+
+// -------------------------------------------------------------------
+// getTaskBlocks のテスト（blocksToMarkdown を間接的に検証）
+// -------------------------------------------------------------------
+describe("getTaskBlocks", () => {
+  beforeEach(() => {
+    mockBlocks.children.list.mockReset()
+  })
+
+  it("file 型の image ブロックを ![caption](url) に変換する", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        {
+          type: "image",
+          image: {
+            type: "file",
+            file: { url: "https://prod-files-secure.s3.us-west-2.amazonaws.com/abc?X-Amz=1" },
+            caption: [{ plain_text: "スクリーンショット" }],
+          },
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+    const md = await getTaskBlocks("page-1")
+    expect(md).toBe("![スクリーンショット](https://prod-files-secure.s3.us-west-2.amazonaws.com/abc?X-Amz=1)")
+  })
+
+  it("external 型の image ブロックを ![](url) に変換する（caption なし）", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        {
+          type: "image",
+          image: {
+            type: "external",
+            external: { url: "https://example.com/img.png" },
+            caption: [],
+          },
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+    const md = await getTaskBlocks("page-1")
+    expect(md).toBe("![](https://example.com/img.png)")
+  })
+
+  it("image とテキストブロックが混在しても順序を保つ", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        {
+          type: "paragraph",
+          paragraph: { rich_text: [{ plain_text: "前文" }] },
+        },
+        {
+          type: "image",
+          image: {
+            type: "external",
+            external: { url: "https://example.com/i.png" },
+            caption: [],
+          },
+        },
+        {
+          type: "paragraph",
+          paragraph: { rich_text: [{ plain_text: "後文" }] },
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+    const md = await getTaskBlocks("page-1")
+    expect(md).toBe("前文\n![](https://example.com/i.png)\n後文")
+  })
+})
+
+// -------------------------------------------------------------------
+// updateTaskBlocks のテスト（編集時の画像保全を検証）
+// -------------------------------------------------------------------
+describe("updateTaskBlocks", () => {
+  beforeEach(() => {
+    mockBlocks.children.list.mockReset()
+    mockBlocks.children.append.mockReset()
+    mockBlocks.delete.mockReset()
+    mockBlocks.children.append.mockResolvedValue({})
+    mockBlocks.delete.mockResolvedValue({})
+  })
+
+  it("image ブロックは delete されず、それ以外は delete される", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "古い本文" }] } },
+        { id: "img1", type: "image", image: { type: "file", file: { url: "https://x.com/a.png" }, caption: [] } },
+        { id: "p2", type: "paragraph", paragraph: { rich_text: [{ plain_text: "別段落" }] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "新しい本文")
+
+    const deletedIds = mockBlocks.delete.mock.calls.map((c: [{ block_id: string }]) => c[0].block_id)
+    expect(deletedIds).toEqual(["p1", "p2"])
+    expect(deletedIds).not.toContain("img1")
+  })
+
+  it("markdown 中の画像行は append されない（既存画像と二重にならない）", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "img1", type: "image", image: { type: "file", file: { url: "https://x.com/a.png" }, caption: [] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "本文行A\n![](https://x.com/a.png)\n本文行B")
+
+    const appendCall = mockBlocks.children.append.mock.calls[0][0]
+    const types = appendCall.children.map((b: { type: string }) => b.type)
+    expect(types).toEqual(["paragraph", "paragraph"])
+    const texts = appendCall.children.map(
+      (b: { paragraph?: { rich_text: Array<{ text: { content: string } }> } }) =>
+        b.paragraph?.rich_text[0].text.content
+    )
+    expect(texts).toEqual(["本文行A", "本文行B"])
+  })
+
+  it("テキストのみの markdown は通常通り append される", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "# 見出し\n本文")
+
+    const appendCall = mockBlocks.children.append.mock.calls[0][0]
+    const types = appendCall.children.map((b: { type: string }) => b.type)
+    expect(types).toEqual(["heading_1", "paragraph"])
   })
 })

--- a/src/lib/mock-tasks.ts
+++ b/src/lib/mock-tasks.ts
@@ -147,6 +147,24 @@ const INITIAL_TASKS: Task[] = [
     createdTime: now,
     lastEditedTime: now,
   },
+  {
+    id: "mock-9",
+    url: "https://notion.so/mock-9",
+    title: "【DEV】画像付きサンプル（ambient agent 経由想定）",
+    status: "進行中",
+    priority: "medium",
+    due: null,
+    tags: ["Tech"],
+    assignees: [],
+    source: null,
+    sourceUrl: null,
+    parentTaskIds: [],
+    childTaskIds: [],
+    prevTaskIds: [],
+    nextTaskIds: [],
+    createdTime: now,
+    lastEditedTime: now,
+  },
 ]
 
 let store: Task[] = INITIAL_TASKS.map((t) => ({ ...t }))
@@ -155,6 +173,7 @@ let nextId = 100
 const mockBlockStore = new Map<string, string>([
   ["mock-1", "## 作業メモ\n\n- ファームウェアバージョン確認\n- バックアップ取得後に適用"],
   ["mock-2", "## 構成\n\n- 導入\n- 本題\n- まとめ"],
+  ["mock-9", "## 概要\n\nambient agent から画像付きで投げられた想定のサンプル。\n\n![参考スクリーンショット](https://picsum.photos/seed/notion-tasks-1/600/400)\n\n## 補足\n\n複数枚も表示できる。\n\n![図解](https://picsum.photos/seed/notion-tasks-2/600/300)\n\n- 編集して保存しても画像は保持される\n- 画像は ![alt](url) の markdown としてレンダリングされる"],
 ])
 
 let mockCommentNextId = 1

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -252,6 +252,18 @@ function blocksToMarkdown(blocks: BlockObjectResponse[]): string {
       lines.push("```")
     } else if (type === "divider") {
       lines.push("---")
+    } else if (type === "image") {
+      const img = b["image"] as {
+        type: "external" | "file"
+        external?: { url: string }
+        file?: { url: string }
+        caption?: Array<{ plain_text: string }>
+      }
+      const url = img.type === "external" ? img.external?.url : img.file?.url
+      if (url) {
+        const caption = img.caption ? extractPlainText(img.caption) : ""
+        lines.push(`![${caption}](${url})`)
+      }
     } else if (type === "paragraph") {
       const rt = (b["paragraph"] as { rich_text: Array<{ plain_text: string }> }).rich_text
       lines.push(extractPlainText(rt))
@@ -392,13 +404,17 @@ export async function createTaskComment(id: string, text: string, author = "Unkn
   }
 }
 
+const IMAGE_MARKDOWN_LINE = /^!\[[^\]]*\]\(.+\)$/
+
 export async function updateTaskBlocks(id: string, markdown: string): Promise<void> {
   if (isDevMode()) {
     updateMockTaskBlocks(id, markdown)
     return
   }
   try {
-    // Fetch and delete existing blocks
+    // Fetch existing blocks; delete only non-image blocks so user-attached
+    // images survive a body edit (file-type Notion images use signed URLs
+    // that can't be safely re-created).
     let cursor: string | undefined = undefined
     do {
       const response = await notion.blocks.children.list({
@@ -407,13 +423,21 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
         ...(cursor ? { start_cursor: cursor } : {}),
       })
       for (const block of response.results) {
+        if (isFullBlockObjectResponse(block) && (block as { type: string }).type === "image") continue
         await notion.blocks.delete({ block_id: block.id })
       }
       cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
     } while (cursor)
 
-    // Append new blocks from markdown
-    const newBlocks = markdownToNotionBlocks(markdown)
+    // Strip image markdown lines: existing image blocks were preserved above,
+    // so re-creating them would duplicate (and create dead links for
+    // Notion-hosted file URLs that have since expired).
+    const textOnly = markdown
+      .split("\n")
+      .filter((line) => !IMAGE_MARKDOWN_LINE.test(line))
+      .join("\n")
+
+    const newBlocks = markdownToNotionBlocks(textOnly)
     if (newBlocks.length > 0) {
       await notion.blocks.children.append({
         block_id: id,


### PR DESCRIPTION
## Summary
- ambient agent から画像付きタスクを登録した際、Notion 側には添付されているのにタスク詳細で表示されない問題を修正。
- あわせて、本文編集→保存時に画像ブロックが全削除される既存挙動を修正し、画像が残るようにする。

## 変更点
- `blocksToMarkdown`: Notion の `image` ブロックを `![caption](url)` の markdown に変換（external / file 両対応）
- `MarkdownPreview`: 画像 markdown 行を `<img>` として描画
- `updateTaskBlocks`: `type==='image'` のブロックは delete せず保持。markdown 中の画像行は二重生成を避けるため append から除外
- `TaskDetail.handleSaveBlocks`: 保存後に `getTaskBlocksAction` で再フェッチし、表示を Notion 上の真の状態に合わせる

## 既知の制限（スコープ外）
- 編集モードで markdown に新しい `![](url)` を書き足しても、保存時には画像ブロックを作成しない（追加は Notion 側で実施）。
- 編集後、Notion 上のブロック順は「画像群 → テキスト群」に再配置される（元の interleave 順は保持しない）。

## Test plan
- [x] `npm run test:unit` — 210 passed
- [x] `npx playwright test` — 30 passed
- [ ] ambient agent から画像付きタスクを登録し、アプリのタスク詳細で画像が表示されることを実環境で確認
- [ ] 画像付きタスクの本文を編集・保存しても画像が消えないことを実環境で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)