### PR TITLE
feat: タスク一覧に期限／優先度のソート機能を追加

### DIFF
--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -86,6 +86,13 @@ test.describe("タスク一覧", () => {
     await filterSelect.selectOption("all")
     await expect(page.locator(`${CENTER} ${TASK_ITEM}`).first()).toBeVisible({ timeout: 10_000 })
 
+    // ソートボタンがビューポート内に収まっていること（スマホで見切れ回帰の検出）
+    const sortBtnBox = await page.locator("[data-testid='sort-button']").boundingBox()
+    const viewport = page.viewportSize()
+    expect(sortBtnBox).not.toBeNull()
+    expect(viewport).not.toBeNull()
+    expect(sortBtnBox!.x + sortBtnBox!.width).toBeLessThanOrEqual(viewport!.width)
+
     const beforeTitles = await page.locator(`${CENTER} [data-testid='task-title']`).allInnerTexts()
     expect(beforeTitles.length).toBeGreaterThan(1)
 

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -7,8 +7,11 @@ const CENTER = "[data-testid='panel-center']"
 const TASK_ITEM = "[data-testid='task-item']"
 
 async function resetAndWait(page: Page) {
-  // フィルタークッキーを active にリセットしてから /reset へ遷移
-  await page.context().addCookies([{ name: "filter", value: "active", domain: "localhost", path: "/" }])
+  // フィルタ／ソート Cookie をデフォルトにリセットしてから /reset へ遷移
+  await page.context().addCookies([
+    { name: "filter", value: "active", domain: "localhost", path: "/" },
+    { name: "sort",   value: JSON.stringify({ key: "default", direction: "asc" }), domain: "localhost", path: "/" },
+  ])
   await page.goto("/reset")
   await expect(page.locator(`${CENTER} ${TASK_ITEM}`).first()).toBeVisible({ timeout: 15_000 })
 }
@@ -76,6 +79,31 @@ test.describe("タスク一覧", () => {
 
     await search.fill("")
     await expect(page.locator(`${CENTER} ${TASK_ITEM}`)).toHaveCount(initial, { timeout: 5_000 })
+  })
+
+  test("ソートシートで期限・降順を適用するとリストが並び替えられる", async ({ page }) => {
+    const filterSelect = page.locator("[data-testid='filter-select']")
+    await filterSelect.selectOption("all")
+    await expect(page.locator(`${CENTER} ${TASK_ITEM}`).first()).toBeVisible({ timeout: 10_000 })
+
+    const beforeTitles = await page.locator(`${CENTER} [data-testid='task-title']`).allInnerTexts()
+    expect(beforeTitles.length).toBeGreaterThan(1)
+
+    await page.locator("[data-testid='sort-button']").click()
+    await expect(page.locator("[data-testid='task-sort-sheet']")).toBeVisible()
+    await page.locator("[data-testid='sort-key-due']").click()
+    await page.locator("[data-testid='sort-dir-desc']").click()
+    await page.getByRole("button", { name: "適用" }).click()
+
+    await expect(page.locator("[data-testid='sort-active-dot']")).toBeVisible()
+    const afterTitles = await page.locator(`${CENTER} [data-testid='task-title']`).allInnerTexts()
+    expect(afterTitles).not.toEqual(beforeTitles)
+
+    // リセットして元の挙動に戻る
+    await page.locator("[data-testid='sort-button']").click()
+    await page.getByRole("button", { name: "リセット" }).click()
+    await page.getByRole("button", { name: "適用" }).click()
+    await expect(page.locator("[data-testid='sort-active-dot']")).toHaveCount(0)
   })
 
   test("ステータスボタンクリックでバッジが楽観的更新される", async ({ page }) => {

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -5,7 +5,7 @@ import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { auth } from "@/auth"
 import { updateTask, createTask, getTaskBlocks, updateTaskBlocks, getTaskComments, createTaskComment, getTasks } from "@/lib/notion"
-import type { AdvancedFilter, Task, TaskStatus, TaskComment, CreateTaskInput, UpdateTaskInput } from "@/types/task"
+import type { AdvancedFilter, SortConfig, Task, TaskStatus, TaskComment, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 import { getQueryStatuses } from "@/constants/filters"
 
 function isDevMode() {
@@ -25,6 +25,10 @@ export async function setFilterAction(filter: string) {
 
 export async function setAdvancedFilterAction(filter: AdvancedFilter) {
   ;(await cookies()).set("filter_advanced", JSON.stringify(filter), { maxAge: 86400, path: "/" })
+}
+
+export async function setSortAction(sort: SortConfig) {
+  ;(await cookies()).set("sort", JSON.stringify(sort), { maxAge: 86400, path: "/" })
 }
 
 export async function fetchTasksByFilterAction(filterKey: string): Promise<Task[]> {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { getTasks, getTagOptions } from "@/lib/notion"
 import { TaskManager } from "@/components/TaskManager"
 import { HydrationCheck } from "@/components/HydrationCheck"
 import { getQueryStatuses, parseAdvancedFilter } from "@/constants/filters"
+import { parseSortConfig } from "@/lib/task-sort"
 
 export default async function Page({
   searchParams,
@@ -18,6 +19,13 @@ export default async function Page({
     advancedFilter = parseAdvancedFilter(advancedRaw ? JSON.parse(advancedRaw) : null)
   } catch {
     advancedFilter = parseAdvancedFilter(null)
+  }
+  const sortRaw = cookieStore.get("sort")?.value
+  let initialSort
+  try {
+    initialSort = parseSortConfig(sortRaw ? JSON.parse(sortRaw) : null)
+  } catch {
+    initialSort = parseSortConfig(null)
   }
   const { task: taskParam } = await searchParams
   const initialTaskId = typeof taskParam === "string" ? taskParam : null
@@ -50,7 +58,7 @@ export default async function Page({
       </header>
 
       <HydrationCheck />
-      <TaskManager tasks={tasks} tagOptions={tagOptions} currentFilter={filter} initialAdvancedFilter={advancedFilter} initialTaskId={initialTaskId} />
+      <TaskManager tasks={tasks} tagOptions={tagOptions} currentFilter={filter} initialAdvancedFilter={advancedFilter} initialSort={initialSort} initialTaskId={initialTaskId} />
     </div>
   )
 }

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,14 +1,15 @@
 "use client"
 
 import { useState, useTransition, useEffect, useRef, useMemo } from "react"
-import type { AdvancedFilter, Task } from "@/types/task"
+import type { AdvancedFilter, SortConfig, Task } from "@/types/task"
 import { TaskItem } from "./TaskItem"
 import { TaskDetail } from "./TaskDetail"
 import { TaskCreate } from "./TaskCreate"
 import { TaskFilterSheet } from "./TaskFilterSheet"
-import { setFilterAction, setAdvancedFilterAction, refreshTasksAction, fetchTasksByFilterAction } from "@/app/actions"
+import { TaskSortSheet } from "./TaskSortSheet"
+import { setFilterAction, setAdvancedFilterAction, setSortAction, refreshTasksAction, fetchTasksByFilterAction } from "@/app/actions"
 import { FILTERS, applyAdvancedFilter, isAdvancedFilterActive } from "@/constants/filters"
-import { sortByPriorityAndDue, groupAndSort } from "@/lib/task-sort"
+import { groupAndSort, applySort, isSortActive } from "@/lib/task-sort"
 
 // ─── TaskListPanel ─────────────────────────────────────────────────────────────
 
@@ -36,12 +37,14 @@ function TaskListPanel({
   tasks,
   searchQuery,
   advancedFilter,
+  sort,
   onSelect,
 }: {
   filterKey: string
   tasks: Task[] | undefined
   searchQuery: string
   advancedFilter: AdvancedFilter
+  sort: SortConfig
   onSelect: (id: string) => void
 }) {
   const current = FILTERS.find((f) => f.key === filterKey) ?? FILTERS[0]
@@ -55,9 +58,10 @@ function TaskListPanel({
     return q === "" ? byAdvanced : byAdvanced.filter((t) => t.title.toLowerCase().includes(q))
   }, [tasks, current.statuses, q, advancedFilter])
 
-  const isGrouped = !current.statuses || current.statuses.length > 1
+  const sortActive = isSortActive(sort)
+  const isGrouped = !sortActive && (!current.statuses || current.statuses.length > 1)
   const groups = isGrouped ? groupAndSort(filtered) : null
-  const sortedFlat = !isGrouped ? sortByPriorityAndDue(filtered) : null
+  const sortedFlat = !isGrouped ? applySort(filtered, sort) : null
 
   if (tasks === undefined) return <TaskSkeleton />
 
@@ -116,17 +120,22 @@ export function TaskManager({
   tagOptions,
   currentFilter,
   initialAdvancedFilter,
+  initialSort,
   initialTaskId,
 }: {
   tasks: Task[]
   tagOptions: string[]
   currentFilter: string
   initialAdvancedFilter: AdvancedFilter
+  initialSort: SortConfig
   initialTaskId?: string | null
 }) {
   const [advancedFilter, setAdvancedFilter] = useState<AdvancedFilter>(initialAdvancedFilter)
+  const [sort, setSort] = useState<SortConfig>(initialSort)
   const [filterSheetOpen, setFilterSheetOpen] = useState(false)
+  const [sortSheetOpen, setSortSheetOpen] = useState(false)
   const advancedActive = isAdvancedFilterActive(advancedFilter)
+  const sortActive = isSortActive(sort)
   const [isPending, startTransition] = useTransition()
   const [completingBar, setCompletingBar] = useState(false)
   const prevIsPendingRef = useRef(isPending)
@@ -391,6 +400,35 @@ export function TaskManager({
               />
             )}
           </button>
+          <button
+            data-testid="sort-button"
+            aria-label="並び替えを開く"
+            onClick={() => setSortSheetOpen(true)}
+            className="relative flex-shrink-0 w-10 self-stretch rounded-xl border border-[rgba(255,0,204,0.3)] bg-[#160022] text-[#ff00cc] flex items-center justify-center hover:border-[#ff00cc] active:scale-95 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3 6h18" />
+              <path d="M6 12h12" />
+              <path d="M10 18h4" />
+            </svg>
+            {sortActive && (
+              <span
+                data-testid="sort-active-dot"
+                className="absolute top-1 right-1 w-2 h-2 rounded-full"
+                style={{ backgroundColor: "#ff00cc", boxShadow: "0 0 6px rgba(255,0,204,0.7)" }}
+              />
+            )}
+          </button>
         </div>
 
         {/* ページネーションドット */}
@@ -438,21 +476,21 @@ export function TaskManager({
           {/* 左パネル（前フィルター） */}
           <div style={{ width: "33.333%", height: "100%", overflowY: "auto" }}>
             <div className="max-w-2xl mx-auto">
-              <TaskListPanel filterKey={left} tasks={taskCache.get(left)} searchQuery={searchQuery} advancedFilter={advancedFilter} onSelect={setSelectedTaskId} />
+              <TaskListPanel filterKey={left} tasks={taskCache.get(left)} searchQuery={searchQuery} advancedFilter={advancedFilter} sort={sort} onSelect={setSelectedTaskId} />
             </div>
           </div>
 
           {/* 中央パネル（現在フィルター） */}
           <div data-testid="panel-center" style={{ width: "33.333%", height: "100%", overflowY: "auto" }}>
             <div className="max-w-2xl mx-auto">
-              <TaskListPanel filterKey={center} tasks={taskCache.get(center)} searchQuery={searchQuery} advancedFilter={advancedFilter} onSelect={setSelectedTaskId} />
+              <TaskListPanel filterKey={center} tasks={taskCache.get(center)} searchQuery={searchQuery} advancedFilter={advancedFilter} sort={sort} onSelect={setSelectedTaskId} />
             </div>
           </div>
 
           {/* 右パネル（次フィルター） */}
           <div style={{ width: "33.333%", height: "100%", overflowY: "auto" }}>
             <div className="max-w-2xl mx-auto">
-              <TaskListPanel filterKey={right} tasks={taskCache.get(right)} searchQuery={searchQuery} advancedFilter={advancedFilter} onSelect={setSelectedTaskId} />
+              <TaskListPanel filterKey={right} tasks={taskCache.get(right)} searchQuery={searchQuery} advancedFilter={advancedFilter} sort={sort} onSelect={setSelectedTaskId} />
             </div>
           </div>
         </div>
@@ -471,6 +509,15 @@ export function TaskManager({
           startTransition(async () => { await setAdvancedFilterAction(next) })
         }}
         onClose={() => setFilterSheetOpen(false)}
+      />
+      <TaskSortSheet
+        open={sortSheetOpen}
+        sort={sort}
+        onApply={(next) => {
+          setSort(next)
+          startTransition(async () => { await setSortAction(next) })
+        }}
+        onClose={() => setSortSheetOpen(false)}
       />
     </div>
   )

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -370,7 +370,7 @@ export function TaskManager({
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="検索..."
             aria-label="タスクを検索"
-            className="flex-1 rounded-xl px-4 py-3 text-sm bg-[#160022] text-[#ffbbee] placeholder:text-[#553355] border border-[rgba(255,0,204,0.3)] focus:outline-none focus:border-[#ff00cc]"
+            className="flex-1 min-w-0 rounded-xl px-4 py-3 text-sm bg-[#160022] text-[#ffbbee] placeholder:text-[#553355] border border-[rgba(255,0,204,0.3)] focus:outline-none focus:border-[#ff00cc]"
             style={{ transition: "border-color 0.2s" }}
           />
           <button

--- a/src/components/TaskSortSheet.tsx
+++ b/src/components/TaskSortSheet.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import type { SortConfig, SortDirection, SortKey } from "@/types/task"
+import { DEFAULT_SORT } from "@/lib/task-sort"
+
+const KEY_OPTIONS: { value: SortKey; label: string }[] = [
+  { value: "default",  label: "デフォルト" },
+  { value: "due",      label: "期限" },
+  { value: "priority", label: "優先度" },
+]
+
+const DIR_OPTIONS: { value: SortDirection; label: string }[] = [
+  { value: "asc",  label: "▲ 昇順" },
+  { value: "desc", label: "▼ 降順" },
+]
+
+const ACTIVE_STYLE = {
+  backgroundColor: "#ff00cc",
+  color: "#0d0014",
+  border: "1px solid transparent",
+  boxShadow: "0 0 8px rgba(255,0,204,0.5)",
+}
+
+const INACTIVE_STYLE = {
+  backgroundColor: "#0d0014",
+  color: "#996688",
+  border: "1px solid rgba(255,0,204,0.2)",
+}
+
+const DISABLED_STYLE = {
+  backgroundColor: "#0d0014",
+  color: "#553355",
+  border: "1px solid rgba(255,0,204,0.1)",
+  opacity: 0.5,
+}
+
+export function TaskSortSheet({
+  open,
+  sort,
+  onApply,
+  onClose,
+}: {
+  open: boolean
+  sort: SortConfig
+  onApply: (next: SortConfig) => void
+  onClose: () => void
+}) {
+  const [draft, setDraft] = useState<SortConfig>(sort)
+
+  useEffect(() => {
+    if (open) setDraft(sort)
+  }, [open, sort])
+
+  function setKey(key: SortKey) {
+    setDraft((d) => ({ ...d, key }))
+  }
+
+  function setDirection(direction: SortDirection) {
+    setDraft((d) => ({ ...d, direction }))
+  }
+
+  function handleReset() {
+    setDraft(DEFAULT_SORT)
+  }
+
+  function handleApply() {
+    onApply(draft)
+    onClose()
+  }
+
+  if (!open) return null
+
+  const directionDisabled = draft.key === "default"
+
+  return (
+    <div data-testid="task-sort-sheet" className="fixed inset-0 z-50 flex flex-col justify-end">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose} />
+
+      <div
+        className="relative rounded-t-2xl px-5 pt-4 pb-10 safe-bottom max-h-[85svh] overflow-y-auto"
+        style={{
+          backgroundColor: "#160022",
+          borderTop: "1px solid rgba(255,0,204,0.5)",
+          boxShadow: "0 -4px 30px rgba(255,0,204,0.2)",
+        }}
+      >
+        <button onClick={onClose} className="w-full flex justify-center pb-2 -mt-1" aria-label="閉じる">
+          <div className="w-10 h-1 rounded-full" style={{ backgroundColor: "rgba(255,0,204,0.4)" }} />
+        </button>
+
+        <h2 className="text-sm text-[#ff00cc] tracking-widest uppercase mb-5 cyber-glow-text-sm">
+          ✦ Sort By
+        </h2>
+
+        <div className="flex flex-col gap-5">
+          <div>
+            <p className="text-xs text-[#996688] mb-2 tracking-widest uppercase">並び替え</p>
+            <div className="flex flex-wrap gap-2">
+              {KEY_OPTIONS.map((opt) => {
+                const active = draft.key === opt.value
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    data-testid={`sort-key-${opt.value}`}
+                    aria-pressed={active}
+                    onClick={() => setKey(opt.value)}
+                    className="px-3 py-2 rounded-full text-xs transition-all"
+                    style={active ? ACTIVE_STYLE : INACTIVE_STYLE}
+                  >
+                    {opt.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs text-[#996688] mb-2 tracking-widest uppercase">方向</p>
+            <div className="flex flex-wrap gap-2">
+              {DIR_OPTIONS.map((opt) => {
+                const active = !directionDisabled && draft.direction === opt.value
+                const style = directionDisabled
+                  ? DISABLED_STYLE
+                  : active
+                    ? ACTIVE_STYLE
+                    : INACTIVE_STYLE
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    data-testid={`sort-dir-${opt.value}`}
+                    aria-pressed={active}
+                    disabled={directionDisabled}
+                    onClick={() => setDirection(opt.value)}
+                    className="px-3 py-2 rounded-full text-xs transition-all"
+                    style={style}
+                  >
+                    {opt.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-3 mt-8">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="flex-1 rounded-xl py-3 text-xs text-[#996688] hover:text-[#ffbbee] transition-colors tracking-widest uppercase"
+            style={{ border: "1px solid rgba(255,0,204,0.25)" }}
+          >
+            リセット
+          </button>
+          <button
+            type="button"
+            onClick={handleApply}
+            className="flex-[2] rounded-xl py-3 text-sm tracking-widest uppercase"
+            style={{
+              backgroundColor: "#ff00cc",
+              color: "#0d0014",
+              boxShadow: "0 0 12px rgba(255,0,204,0.5), 0 0 30px rgba(255,0,204,0.2)",
+            }}
+          >
+            適用
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, act, waitFor, within } from "@testing-library/react"
 import { TaskManager } from "@/components/TaskManager"
 import { FILTERS } from "@/constants/filters"
+import { DEFAULT_SORT } from "@/lib/task-sort"
 import type { Task } from "@/types/task"
 
 vi.mock("@/app/actions", () => ({
   setFilterAction: vi.fn().mockResolvedValue(undefined),
   setAdvancedFilterAction: vi.fn().mockResolvedValue(undefined),
+  setSortAction: vi.fn().mockResolvedValue(undefined),
   refreshTasksAction: vi.fn().mockResolvedValue(undefined),
   fetchTasksByFilterAction: vi.fn().mockResolvedValue([]),
 }))
@@ -82,7 +84,7 @@ afterEach(() => {
 
 describe("TaskManager フィルター", () => {
   it("active フィルターは進行中・未着手のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
@@ -92,40 +94,40 @@ describe("TaskManager フィルター", () => {
   })
 
   it("todo フィルターは未着手のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="todo" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("doing フィルターは進行中のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="doing" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="doing" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("未着手タスク")).not.toBeInTheDocument()
   })
 
   it("review フィルターは確認中のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="review" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="review" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("確認中タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("paused フィルターは一時中断のみを表示する", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="paused" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="paused" />)
     const panel = getCenterPanel()
     expect(within(panel).getByText("一時中断タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("進行中タスク")).not.toBeInTheDocument()
   })
 
   it("all フィルターはすべてのタスクを表示する", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="all" />)
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(5)
   })
 
   it("不明なフィルターキーは active にフォールバックする", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="unknown-key" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="unknown-key" />)
     const panel = getCenterPanel()
     // active = 進行中・未着手
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
@@ -134,19 +136,19 @@ describe("TaskManager フィルター", () => {
   })
 
   it("タスク数を表示する", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="all" />)
     expect(within(getCenterPanel()).getByText("5 TASKS")).toBeInTheDocument()
   })
 
   it("フィルターに一致するタスクがない場合「タスクがありません」を表示する", () => {
     const noTasks = [makeTask({ status: "完了" })]
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={noTasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={noTasks} currentFilter="todo" />)
     expect(within(getCenterPanel()).getByText("— NO TASKS —")).toBeInTheDocument()
   })
 
   it("status が null のタスクは any ステータスフィルターにマッチしない", () => {
     const nullStatusTasks = [makeTask({ id: "n1", title: "ステータス不明", status: null })]
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={nullStatusTasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={nullStatusTasks} currentFilter="active" />)
     expect(within(getCenterPanel()).queryByText("ステータス不明")).not.toBeInTheDocument()
   })
 })
@@ -173,7 +175,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("左スワイプ 80px で active(0番) → todo(1番) に変わる", async () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), -80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -182,7 +184,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("右スワイプ 80px で todo(1番) → active(0番) に戻る", async () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="todo" />)
     act(() => { swipe(getMain(), 80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -191,7 +193,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("左スワイプ @ all(末尾) → active(先頭) に循環する", async () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="all" />)
     act(() => { swipe(getMain(), -80) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -201,14 +203,14 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("右スワイプ @ active(先頭) → all(末尾) に循環する", async () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), 80) })
     await act(async () => { vi.runAllTimers() })
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(5)
   })
 
   it("50px スワイプ（閾値未満）ではフィルターが変わらない", async () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), -50) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -218,7 +220,7 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("縦スワイプ (dx=30, dy=200) ではフィルターが変わらない", async () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
     act(() => { swipe(getMain(), 30, 200) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
@@ -233,7 +235,7 @@ function getSearchInput() {
 
 describe("インクリメンタルサーチ", () => {
   it("タイトル部分一致で絞り込まれる", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "進行中" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
@@ -247,7 +249,7 @@ describe("インクリメンタルサーチ", () => {
       makeTask({ id: "e1", title: "Refactor API", status: "進行中" }),
       makeTask({ id: "e2", title: "Write Tests", status: "未着手" }),
     ]
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={englishTasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={englishTasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "refactor" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("Refactor API")).toBeInTheDocument()
@@ -255,7 +257,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("空入力で全件に戻る", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="all" />)
     const input = getSearchInput()
     fireEvent.change(input, { target: { value: "進行中" } })
     expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(1)
@@ -264,7 +266,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("マッチが無いとき NO MATCH を表示する", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="all" />)
     fireEvent.change(getSearchInput(), { target: { value: "存在しない文字列" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("— NO MATCH —")).toBeInTheDocument()
@@ -272,7 +274,7 @@ describe("インクリメンタルサーチ", () => {
   })
 
   it("status フィルターと AND で組み合わさる", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="todo" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="todo" />)
     fireEvent.change(getSearchInput(), { target: { value: "タスク" } })
     const panel = getCenterPanel()
     expect(within(panel).getByText("未着手タスク")).toBeInTheDocument()
@@ -282,7 +284,7 @@ describe("インクリメンタルサーチ", () => {
   it("swipe してフィルターが変わってもクエリは保持される", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout"] })
     try {
-      render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="all" />)
+      render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="all" />)
       fireEvent.change(getSearchInput(), { target: { value: "進行中" } })
       expect(within(getCenterPanel()).getAllByTestId("task-item")).toHaveLength(1)
 
@@ -298,14 +300,57 @@ describe("インクリメンタルサーチ", () => {
   })
 })
 
+describe("ソート", () => {
+  const sortableTasks: Task[] = [
+    makeTask({ id: "p1", title: "高",   status: "未着手", priority: "high",   due: "2024-04-01" }),
+    makeTask({ id: "p2", title: "中",   status: "進行中", priority: "medium", due: "2024-02-01" }),
+    makeTask({ id: "p3", title: "低",   status: "未着手", priority: "low",    due: "2024-06-01" }),
+  ]
+
+  it("ソートボタン押下で TaskSortSheet が開く", () => {
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={sortableTasks} currentFilter="active" />)
+    expect(screen.queryByTestId("task-sort-sheet")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId("sort-button"))
+    expect(screen.getByTestId("task-sort-sheet")).toBeInTheDocument()
+  })
+
+  it("default の active フィルター（複数ステータス）はステータスヘッダーが表示される", () => {
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={sortableTasks} currentFilter="active" />)
+    const panel = getCenterPanel()
+    expect(within(panel).getByText("未着手")).toBeInTheDocument()
+    expect(within(panel).getByText("進行中")).toBeInTheDocument()
+  })
+
+  it("ソート適用時はグルーピングが解除されフラット表示になる", () => {
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={{ key: "due", direction: "asc" }} tasks={sortableTasks} currentFilter="active" />)
+    const panel = getCenterPanel()
+    // ステータスヘッダーが消える
+    expect(within(panel).queryByText("未着手")).not.toBeInTheDocument()
+    expect(within(panel).queryByText("進行中")).not.toBeInTheDocument()
+    // 期限昇順: p2 → p1 → p3
+    const items = within(panel).getAllByTestId("task-item")
+    expect(items.map((el) => el.getAttribute("data-task-id"))).toEqual(["p2", "p1", "p3"])
+  })
+
+  it("ソート active 時に sort-active-dot が表示される", () => {
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={{ key: "priority", direction: "desc" }} tasks={sortableTasks} currentFilter="all" />)
+    expect(screen.getByTestId("sort-active-dot")).toBeInTheDocument()
+  })
+
+  it("default ソート時は sort-active-dot が表示されない", () => {
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={sortableTasks} currentFilter="all" />)
+    expect(screen.queryByTestId("sort-active-dot")).not.toBeInTheDocument()
+  })
+})
+
 describe("ページネーションドット", () => {
   it("FILTERS の数だけドットが表示される", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
     expect(screen.getAllByRole("tab")).toHaveLength(FILTERS.length)
   })
 
   it("現在フィルターのドットが aria-selected=true、他は false", () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="review" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="review" />)
     const dots = screen.getAllByRole("tab")
     const activeIdx = FILTERS.findIndex((f) => f.key === "review")
     dots.forEach((dot, i) => {
@@ -314,7 +359,7 @@ describe("ページネーションドット", () => {
   })
 
   it("ドットをクリックするとフィルターが変わる", async () => {
-    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} tasks={tasks} currentFilter="active" />)
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
     const allDot = screen.getByRole("tab", { name: "すべて" })
     await act(async () => { fireEvent.click(allDot) })
     await waitFor(() => {

--- a/src/components/__tests__/TaskSortSheet.test.tsx
+++ b/src/components/__tests__/TaskSortSheet.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { TaskSortSheet } from "@/components/TaskSortSheet"
+import { DEFAULT_SORT } from "@/lib/task-sort"
+import type { SortConfig } from "@/types/task"
+
+describe("TaskSortSheet 表示", () => {
+  it("open=false のとき何もレンダリングしない", () => {
+    const { container } = render(
+      <TaskSortSheet open={false} sort={DEFAULT_SORT} onApply={vi.fn()} onClose={vi.fn()} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("open=true のとき各セクションが表示される", () => {
+    render(<TaskSortSheet open={true} sort={DEFAULT_SORT} onApply={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByText("並び替え")).toBeInTheDocument()
+    expect(screen.getByText("方向")).toBeInTheDocument()
+    expect(screen.getByTestId("sort-key-default")).toBeInTheDocument()
+    expect(screen.getByTestId("sort-key-due")).toBeInTheDocument()
+    expect(screen.getByTestId("sort-key-priority")).toBeInTheDocument()
+  })
+
+  it("default 選択時は方向ボタンが disabled", () => {
+    render(<TaskSortSheet open={true} sort={DEFAULT_SORT} onApply={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByTestId("sort-dir-asc")).toBeDisabled()
+    expect(screen.getByTestId("sort-dir-desc")).toBeDisabled()
+  })
+
+  it("default 以外を選んだ後は方向ボタンが有効化される", () => {
+    render(<TaskSortSheet open={true} sort={DEFAULT_SORT} onApply={vi.fn()} onClose={vi.fn()} />)
+    fireEvent.click(screen.getByTestId("sort-key-due"))
+    expect(screen.getByTestId("sort-dir-asc")).toBeEnabled()
+    expect(screen.getByTestId("sort-dir-desc")).toBeEnabled()
+  })
+})
+
+describe("TaskSortSheet 操作", () => {
+  function setup(sort: SortConfig = DEFAULT_SORT) {
+    const onApply = vi.fn()
+    const onClose = vi.fn()
+    render(<TaskSortSheet open={true} sort={sort} onApply={onApply} onClose={onClose} />)
+    return { onApply, onClose }
+  }
+
+  it("期限を選び降順で適用", () => {
+    const { onApply, onClose } = setup()
+    fireEvent.click(screen.getByTestId("sort-key-due"))
+    fireEvent.click(screen.getByTestId("sort-dir-desc"))
+    fireEvent.click(screen.getByRole("button", { name: "適用" }))
+    expect(onApply).toHaveBeenCalledWith({ key: "due", direction: "desc" })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("優先度を選び昇順（デフォルト方向）で適用", () => {
+    const { onApply } = setup()
+    fireEvent.click(screen.getByTestId("sort-key-priority"))
+    fireEvent.click(screen.getByRole("button", { name: "適用" }))
+    expect(onApply).toHaveBeenCalledWith({ key: "priority", direction: "asc" })
+  })
+
+  it("リセットで draft が DEFAULT_SORT に戻る（適用前）", () => {
+    const { onApply } = setup({ key: "priority", direction: "desc" })
+    fireEvent.click(screen.getByRole("button", { name: "リセット" }))
+    fireEvent.click(screen.getByRole("button", { name: "適用" }))
+    expect(onApply).toHaveBeenCalledWith(DEFAULT_SORT)
+  })
+
+  it("バックドロップクリックで onClose、適用前なので onApply は呼ばれない", () => {
+    const { onApply, onClose } = setup()
+    fireEvent.click(screen.getByTestId("sort-key-due"))
+    const backdrop = document.querySelector('[class*="bg-black"]') as HTMLElement
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalled()
+    expect(onApply).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/__tests__/task-sort.test.ts
+++ b/src/lib/__tests__/task-sort.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest"
+import {
+  applySort,
+  DEFAULT_SORT,
+  isSortActive,
+  parseSortConfig,
+  sortByPriorityAndDue,
+} from "@/lib/task-sort"
+import type { SortConfig, Task } from "@/types/task"
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: "t1",
+    url: "https://notion.so/t1",
+    title: "task",
+    status: "未着手",
+    priority: null,
+    due: null,
+    tags: [],
+    assignees: [],
+    source: null,
+    sourceUrl: null,
+    parentTaskIds: [],
+    childTaskIds: [],
+    prevTaskIds: [],
+    nextTaskIds: [],
+    createdTime: "2024-01-01T00:00:00.000Z",
+    lastEditedTime: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("isSortActive", () => {
+  it("default は非アクティブ", () => {
+    expect(isSortActive({ key: "default", direction: "asc" })).toBe(false)
+    expect(isSortActive(DEFAULT_SORT)).toBe(false)
+  })
+  it("default 以外はアクティブ", () => {
+    expect(isSortActive({ key: "due", direction: "asc" })).toBe(true)
+    expect(isSortActive({ key: "priority", direction: "desc" })).toBe(true)
+  })
+})
+
+describe("parseSortConfig", () => {
+  it("null/undefined はデフォルト", () => {
+    expect(parseSortConfig(null)).toEqual(DEFAULT_SORT)
+    expect(parseSortConfig(undefined)).toEqual(DEFAULT_SORT)
+  })
+  it("不正な型はデフォルトにフォールバック", () => {
+    expect(parseSortConfig("not-an-object")).toEqual(DEFAULT_SORT)
+    expect(parseSortConfig(123)).toEqual(DEFAULT_SORT)
+  })
+  it("不正な key/direction は安全側にフォールバック", () => {
+    expect(parseSortConfig({ key: "bogus", direction: "asc" })).toEqual(DEFAULT_SORT)
+    expect(parseSortConfig({ key: "due", direction: "weird" })).toEqual({ key: "due", direction: "asc" })
+  })
+  it("正常値はそのまま返る", () => {
+    expect(parseSortConfig({ key: "priority", direction: "desc" })).toEqual({ key: "priority", direction: "desc" })
+  })
+})
+
+describe("applySort: default", () => {
+  it("default は sortByPriorityAndDue と一致", () => {
+    const tasks = [
+      makeTask({ id: "a", priority: "low",  due: "2024-03-01" }),
+      makeTask({ id: "b", priority: "high", due: "2024-04-01" }),
+      makeTask({ id: "c", priority: null,   due: "2024-02-01" }),
+      makeTask({ id: "d", priority: "high", due: "2024-01-01" }),
+    ]
+    const expected = sortByPriorityAndDue(tasks).map((t) => t.id)
+    expect(applySort(tasks, DEFAULT_SORT).map((t) => t.id)).toEqual(expected)
+  })
+})
+
+describe("applySort: due", () => {
+  const tasks = [
+    makeTask({ id: "a", due: "2024-03-01" }),
+    makeTask({ id: "b", due: null }),
+    makeTask({ id: "c", due: "2024-01-15" }),
+    makeTask({ id: "d", due: "2024-05-10" }),
+  ]
+
+  it("昇順: 古い→新しい、null は末尾", () => {
+    const ids = applySort(tasks, { key: "due", direction: "asc" }).map((t) => t.id)
+    expect(ids).toEqual(["c", "a", "d", "b"])
+  })
+
+  it("降順: 新しい→古い、null は末尾", () => {
+    const ids = applySort(tasks, { key: "due", direction: "desc" }).map((t) => t.id)
+    expect(ids).toEqual(["d", "a", "c", "b"])
+  })
+
+  it("null のみでも安全に返る", () => {
+    const onlyNull = [makeTask({ id: "x", due: null }), makeTask({ id: "y", due: null })]
+    const ids = applySort(onlyNull, { key: "due", direction: "asc" }).map((t) => t.id)
+    expect(ids).toEqual(["x", "y"])
+  })
+
+  it("元配列を破壊しない", () => {
+    const before = tasks.map((t) => t.id)
+    applySort(tasks, { key: "due", direction: "desc" })
+    expect(tasks.map((t) => t.id)).toEqual(before)
+  })
+})
+
+describe("applySort: priority", () => {
+  const tasks = [
+    makeTask({ id: "a", priority: "medium" }),
+    makeTask({ id: "b", priority: null }),
+    makeTask({ id: "c", priority: "high" }),
+    makeTask({ id: "d", priority: "low" }),
+  ]
+
+  it("昇順: high → medium → low、null は末尾", () => {
+    const ids = applySort(tasks, { key: "priority", direction: "asc" }).map((t) => t.id)
+    expect(ids).toEqual(["c", "a", "d", "b"])
+  })
+
+  it("降順: low → medium → high、null は末尾", () => {
+    const ids = applySort(tasks, { key: "priority", direction: "desc" }).map((t) => t.id)
+    expect(ids).toEqual(["d", "a", "c", "b"])
+  })
+})

--- a/src/lib/task-sort.ts
+++ b/src/lib/task-sort.ts
@@ -1,10 +1,15 @@
-import type { Task, TaskStatus } from "@/types/task"
+import type { SortConfig, SortDirection, SortKey, Task, TaskStatus } from "@/types/task"
 
 const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 } as const
 
 export const STATUS_ORDER: TaskStatus[] = [
   "未着手", "進行中", "確認中", "一時中断", "完了", "中止", "アーカイブ済み",
 ]
+
+export const DEFAULT_SORT: SortConfig = { key: "default", direction: "asc" }
+
+const SORT_KEYS: readonly SortKey[] = ["default", "due", "priority"]
+const SORT_DIRECTIONS: readonly SortDirection[] = ["asc", "desc"]
 
 export function sortByPriorityAndDue(tasks: Task[]): Task[] {
   return [...tasks].sort((a, b) => {
@@ -28,4 +33,41 @@ export function groupAndSort(tasks: Task[]): { status: TaskStatus; tasks: Task[]
   return STATUS_ORDER
     .filter((s) => map.has(s))
     .map((s) => ({ status: s, tasks: sortByPriorityAndDue(map.get(s)!) }))
+}
+
+export function isSortActive(sort: SortConfig): boolean {
+  return sort.key !== "default"
+}
+
+/** 不正値や古いスキーマで落ちないよう各フィールドを検証 */
+export function parseSortConfig(raw: unknown): SortConfig {
+  if (!raw || typeof raw !== "object") return DEFAULT_SORT
+  const obj = raw as Record<string, unknown>
+  const key = SORT_KEYS.includes(obj.key as SortKey) ? (obj.key as SortKey) : "default"
+  const direction = SORT_DIRECTIONS.includes(obj.direction as SortDirection)
+    ? (obj.direction as SortDirection)
+    : "asc"
+  return { key, direction }
+}
+
+export function applySort(tasks: Task[], sort: SortConfig): Task[] {
+  if (sort.key === "default") return sortByPriorityAndDue(tasks)
+  const sign = sort.direction === "asc" ? 1 : -1
+  if (sort.key === "due") {
+    return [...tasks].sort((a, b) => {
+      if (!a.due && !b.due) return 0
+      if (!a.due) return 1
+      if (!b.due) return -1
+      return a.due.localeCompare(b.due) * sign
+    })
+  }
+  // priority
+  return [...tasks].sort((a, b) => {
+    const pa = a.priority != null ? PRIORITY_ORDER[a.priority] : 3
+    const pb = b.priority != null ? PRIORITY_ORDER[b.priority] : 3
+    if (pa === 3 && pb === 3) return 0
+    if (pa === 3) return 1
+    if (pb === 3) return -1
+    return (pa - pb) * sign
+  })
 }

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -56,3 +56,7 @@ export type AdvancedFilter = {
   dueDate: DueDateMode
   priorities: TaskPriority[]
 }
+
+export type SortKey = "default" | "due" | "priority"
+export type SortDirection = "asc" | "desc"
+export type SortConfig = { key: SortKey; direction: SortDirection }


### PR DESCRIPTION
## Summary
- フィルタボタンの隣にソート専用ボタンを設置し、`TaskSortSheet` から「期限／優先度」を昇順／降順で並び替えられるようにした
- デフォルトは従来の固定ソート（優先度 high→low → 期限昇順）を維持。ユーザーが任意のキーを選んだ場合は status グルーピングを解除してフラット表示に切り替える
- 設定は `sort` Cookie に JSON で 24h 永続化（フィルタと同じパターン）

## Test plan
- [x] `npm run test:unit`（236 passed）
- [x] `npx playwright test`（32 passed）— 新規 E2E でソート適用→アクティブドット表示→リセットまで検証
- [ ] ブラウザで `期限／降順`、`優先度／昇順` を切り替えてリストが並び替わることを目視確認
- [ ] 「すべて」フィルタでソート適用時にステータスヘッダーが消えてフラット表示になることを確認
- [ ] リロードで Cookie 経由の並び順が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)