### PR TITLE
fix: タスク作成シート表示中の背景スクロール抑制

### DIFF
--- a/src/components/TaskCreate.tsx
+++ b/src/components/TaskCreate.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef, useTransition } from "react"
+import { useEffect, useState, useRef, useTransition } from "react"
 import { useFormStatus } from "react-dom"
 import { createTaskAction } from "@/app/actions"
 import { buildDue } from "@/lib/due-date"
@@ -32,6 +32,13 @@ export function TaskCreate({ tagOptions }: { tagOptions: string[] }) {
   const [dueTime, setDueTime] = useState("")
   const [, startTransition] = useTransition()
   const formRef = useRef<HTMLFormElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => { document.body.style.overflow = prev }
+  }, [open])
 
   function toggleTag(tag: string) {
     setSelectedTags((prev) =>
@@ -95,7 +102,7 @@ export function TaskCreate({ tagOptions }: { tagOptions: string[] }) {
           <div className="absolute inset-0 bg-black/70" onClick={handleClose} />
 
           <div
-            className="relative rounded-t-2xl px-5 pt-4 pb-10 safe-bottom max-h-[85svh] overflow-y-auto"
+            className="relative rounded-t-2xl px-5 pt-4 pb-10 safe-bottom max-h-[85svh] overflow-y-auto overscroll-contain"
             style={{
               backgroundColor: "#160022",
               borderTop: "1px solid rgba(255,0,204,0.5)",


### PR DESCRIPTION
## Summary
- タスク作成シートを開いて下方向にスクロールしたとき、シート末尾を超えると裏のタスク一覧まで動いてしまう問題を修正
- シートが開いている間は `document.body.style.overflow = \"hidden\"` で背景スクロールを抑制（既存の TaskDetail と同じ手法）
- 念のためシート自体にも `overscroll-contain` を付け、iOS のラバーバンド由来のスクロール連鎖も防ぐ

## Test plan
- [x] \`npm run test:unit\` 全パス（236 件）
- [x] \`npx playwright test\` 全パス（32 件）
- [ ] 実機/ブラウザでタスク作成シートを開き、内容を下までスクロールしても裏のタスク一覧が動かないことを確認
- [ ] シートを閉じた後、元通りページがスクロールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)