### PR TITLE
feat: タスク一覧をプルダウンでリフレッシュできるようにする

### DIFF
--- a/e2e/pull-refresh.spec.ts
+++ b/e2e/pull-refresh.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test"
+import type { Page, CDPSession } from "@playwright/test"
+
+test.use({ storageState: "e2e/.auth/user.json" })
+
+const CENTER = "[data-testid='panel-center']"
+const TASK_ITEM = "[data-testid='task-item']"
+const PULL_INDICATOR = "[data-testid='pull-indicator']"
+
+async function resetAndWait(page: Page) {
+  await page.context().addCookies([{ name: "filter", value: "active", domain: "localhost", path: "/" }])
+  await page.goto("/reset")
+  await expect(page.locator(`${CENTER} ${TASK_ITEM}`).first()).toBeVisible({ timeout: 15_000 })
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {})
+}
+
+async function swipe(cdp: CDPSession, sx: number, sy: number, dx: number, dy = 0) {
+  const STEPS = 8
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x: sx, y: sy, radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1 }],
+  })
+  for (let i = 1; i <= STEPS; i++) {
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [{ x: sx + (dx * i) / STEPS, y: sy + (dy * i) / STEPS, radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1 }],
+    })
+  }
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [{ x: sx + dx, y: sy + dy, radiusX: 1, radiusY: 1, rotationAngle: 0, force: 0 }],
+  })
+}
+
+async function getSwipeOrigin(page: Page) {
+  // 中央パネルの上部付近を起点にする（最上部からの下方向プルを正しく再現するため）
+  const box = await page.locator("[data-testid='task-list-main']").boundingBox()
+  if (!box) throw new Error("task-list-main not found")
+  return { sx: box.x + box.width / 2, sy: box.y + 40 }
+}
+
+test.describe("プル・トゥ・リフレッシュ", () => {
+  test.describe.configure({ mode: "serial" })
+
+  test.beforeEach(async ({ page }) => {
+    await resetAndWait(page)
+  })
+
+  test("インジケーターが DOM に存在する", async ({ page }) => {
+    await expect(page.locator(PULL_INDICATOR)).toBeAttached()
+  })
+
+  test("最上部からの下方向プルでインジケーターが現れる", async ({ page, context }) => {
+    const indicator = page.locator(PULL_INDICATOR)
+    // 初期は不可視
+    await expect(indicator).toHaveCSS("opacity", "0")
+
+    const cdp = await context.newCDPSession(page)
+    const { sx, sy } = await getSwipeOrigin(page)
+
+    // touchStart → touchMove のみ送って中間状態のスタイルを確認するため、手動で touchEnd を遅延
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x: sx, y: sy, radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1 }],
+    })
+    for (let i = 1; i <= 8; i++) {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: sx, y: sy + (200 * i) / 8, radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1 }],
+      })
+    }
+    // touchEnd 前にインジケーターが見えていることを確認
+    await expect(indicator).toHaveCSS("opacity", "1", { timeout: 1_000 })
+    await expect(indicator).toHaveAttribute("data-ready", "true")
+
+    // 後始末：touchEnd を発火してリフレッシュ起動
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [{ x: sx, y: sy + 200, radiusX: 1, radiusY: 1, rotationAngle: 0, force: 0 }],
+    })
+  })
+
+  test("中央パネルがスクロール下方の場合はインジケーターが現れない", async ({ page, context }) => {
+    await page.evaluate(() => {
+      const panel = document.querySelector("[data-testid='panel-center']") as HTMLElement
+      panel.scrollTop = 100
+    })
+
+    const indicator = page.locator(PULL_INDICATOR)
+    await expect(indicator).toHaveCSS("opacity", "0")
+
+    const cdp = await context.newCDPSession(page)
+    const { sx, sy } = await getSwipeOrigin(page)
+    await swipe(cdp, sx, sy, 0, 200)
+
+    // インジケーターは出現しないまま
+    await page.waitForTimeout(300)
+    await expect(indicator).toHaveCSS("opacity", "0")
+  })
+})

--- a/e2e/swipe.spec.ts
+++ b/e2e/swipe.spec.ts
@@ -74,6 +74,12 @@ test.describe("スワイプナビゲーション", () => {
     const filterSelect = page.locator("[data-testid='filter-select']")
     await expect(filterSelect).toHaveValue("active")
 
+    // 中央パネルをスクロール下方向に動かして pull-to-refresh が発動しない条件にする
+    await page.evaluate(() => {
+      const panel = document.querySelector("[data-testid='panel-center']") as HTMLElement
+      panel.scrollTop = 100
+    })
+
     const cdp = await context.newCDPSession(page)
     const { sx, sy } = await getSwipeOrigin(page)
     await swipe(cdp, sx, sy, 20, 200)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,10 +33,10 @@ export default defineConfig({
         storageState: "e2e/.auth/user.json",
       },
       dependencies: ["setup"],
-      testIgnore: ["**/swipe.spec.ts"],
+      testIgnore: ["**/swipe.spec.ts", "**/pull-refresh.spec.ts"],
     },
     {
-      // スワイプは CDP が必要なため Chromium で実行
+      // スワイプ／プルリフレッシュは CDP が必要なため Chromium で実行
       name: "Chromium Touch",
       use: {
         ...devices["iPhone 15"],
@@ -45,7 +45,7 @@ export default defineConfig({
         storageState: "e2e/.auth/user.json",
       },
       dependencies: ["setup"],
-      testMatch: ["**/swipe.spec.ts"],
+      testMatch: ["**/swipe.spec.ts", "**/pull-refresh.spec.ts"],
     },
     {
       name: "Desktop Chrome",
@@ -54,7 +54,7 @@ export default defineConfig({
         storageState: "e2e/.auth/user.json",
       },
       dependencies: ["setup"],
-      testIgnore: ["**/swipe.spec.ts", "**/snapshot.spec.ts", "**/pwa.spec.ts"],
+      testIgnore: ["**/swipe.spec.ts", "**/pull-refresh.spec.ts", "**/snapshot.spec.ts", "**/pwa.spec.ts"],
     },
   ],
   webServer: {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -109,3 +109,9 @@ option {
 .task-list[data-filter="doing"]  li:not([data-status="進行中"])  { display: none; }
 .task-list[data-filter="review"] li:not([data-status="確認中"])  { display: none; }
 .task-list[data-filter="paused"] li:not([data-status="一時中断"]) { display: none; }
+
+/* プル・トゥ・リフレッシュ閾値到達時の視覚フィードバック */
+[data-testid="pull-indicator"][data-ready="true"] {
+  border-color: #ff00cc !important;
+  box-shadow: 0 0 12px rgba(255, 0, 204, 0.8) !important;
+}

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -143,6 +143,13 @@ export function TaskManager({
     if (prevIsPendingRef.current && !isPending) {
       setCompletingBar(true)
       const timer = setTimeout(() => setCompletingBar(false), 400)
+      const ind = pullIndicatorRef.current
+      if (ind) {
+        ind.style.transition = "transform 250ms ease-out, opacity 250ms ease-out"
+        ind.style.transform = "translate(-50%, 0)"
+        ind.style.opacity = "0"
+        ind.dataset.ready = "false"
+      }
       return () => clearTimeout(timer)
     }
     prevIsPendingRef.current = isPending
@@ -195,6 +202,13 @@ export function TaskManager({
   const selectedTaskIdRef = useRef<string | null>(selectedTaskId)
   const isPendingRef = useRef(false)
 
+  // ─── Pull-to-refresh refs ─────────────────────────────────────────────────
+  const centerPanelRef = useRef<HTMLDivElement>(null)
+  const pullIndicatorRef = useRef<HTMLDivElement>(null)
+  const pullDistanceRef = useRef(0)
+  const isPullingRef = useRef(false)
+  const startScrollTopRef = useRef(0)
+
   useEffect(() => { centerIndexRef.current = centerIndex }, [centerIndex])
   useEffect(() => { selectedTaskIdRef.current = selectedTaskId }, [selectedTaskId])
   useEffect(() => { isPendingRef.current = isPending }, [isPending])
@@ -205,12 +219,18 @@ export function TaskManager({
     if (!el) return
     const THRESHOLD = 60
     const LOCK_DIST = 8
+    const PULL_THRESHOLD = 64
+    const PULL_LOCK_POSITION = 48
+    const PULL_DAMPING = 0.5
 
     const touchStartXRef = { current: 0 }
     const touchStartYRef = { current: 0 }
-    const directionRef = { current: null as "horiz" | "vert" | null }
+    const directionRef = { current: null as "horiz" | "vert" | "pull" | null }
 
     function onStart(e: TouchEvent) {
+      isPullingRef.current = false
+      pullDistanceRef.current = 0
+      startScrollTopRef.current = centerPanelRef.current?.scrollTop ?? 0
       if (e.touches.length > 1) { directionRef.current = "vert"; return }
       if (isAnimatingRef.current) return
       touchStartXRef.current = e.touches[0].clientX
@@ -227,6 +247,40 @@ export function TaskManager({
         if (Math.hypot(dx, dy) < LOCK_DIST) return
         directionRef.current = Math.abs(dx) > Math.abs(dy) ? "horiz" : "vert"
       }
+
+      // vert 確定後、最上部から下方向にドラッグなら pull に昇格
+      if (directionRef.current === "vert") {
+        if (
+          e.touches.length === 1 &&
+          dy > 0 &&
+          startScrollTopRef.current === 0 &&
+          !isPendingRef.current &&
+          selectedTaskIdRef.current === null
+        ) {
+          directionRef.current = "pull"
+        } else {
+          return  // 通常の縦スクロールに任せる
+        }
+      }
+
+      if (directionRef.current === "pull") {
+        e.preventDefault()
+        const damped = Math.max(0, dy) * PULL_DAMPING
+        pullDistanceRef.current = damped
+        isPullingRef.current = true
+
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = requestAnimationFrame(() => {
+          const ind = pullIndicatorRef.current
+          if (!ind) return
+          ind.style.transition = "none"
+          ind.style.transform = `translate(-50%, ${damped}px)`
+          ind.style.opacity = String(Math.min(1, damped / 30))
+          ind.dataset.ready = damped >= PULL_THRESHOLD ? "true" : "false"
+        })
+        return
+      }
+
       if (directionRef.current !== "horiz") return
 
       e.preventDefault()
@@ -241,8 +295,30 @@ export function TaskManager({
       })
     }
 
+    function animatePullIndicator(targetY: number) {
+      const ind = pullIndicatorRef.current
+      if (!ind) return
+      ind.style.transition = "transform 200ms ease-out, opacity 200ms ease-out"
+      ind.style.transform = `translate(-50%, ${targetY}px)`
+      ind.style.opacity = targetY > 0 ? "1" : "0"
+    }
+
     function onEnd(e: TouchEvent) {
       cancelAnimationFrame(rafRef.current)
+
+      if (directionRef.current === "pull") {
+        const damped = pullDistanceRef.current
+        isPullingRef.current = false
+        pullDistanceRef.current = 0
+        if (damped >= PULL_THRESHOLD) {
+          animatePullIndicator(PULL_LOCK_POSITION)
+          startTransition(async () => { await refreshTasksAction() })
+        } else {
+          animatePullIndicator(0)
+        }
+        return
+      }
+
       if (directionRef.current !== "horiz") return
       if (selectedTaskIdRef.current !== null) return
       if (isPendingRef.current) return
@@ -466,8 +542,48 @@ export function TaskManager({
       <main
         ref={mainRef}
         data-testid="task-list-main"
-        className="flex-1 overflow-hidden"
+        className="relative flex-1 overflow-hidden"
       >
+        {/* プルインジケーター */}
+        <div
+          ref={pullIndicatorRef}
+          data-testid="pull-indicator"
+          aria-hidden="true"
+          className="absolute pointer-events-none flex items-center justify-center"
+          style={{
+            top: -32,
+            left: "50%",
+            width: 32,
+            height: 32,
+            borderRadius: 16,
+            backgroundColor: "#160022",
+            border: "1px solid rgba(255,0,204,0.4)",
+            boxShadow: "0 0 8px rgba(255,0,204,0.4)",
+            transform: "translate(-50%, 0)",
+            opacity: 0,
+            zIndex: 20,
+            transition: "transform 200ms ease-out, opacity 200ms ease-out",
+          }}
+        >
+          <svg
+            className={isPending ? "animate-spin-cyber" : ""}
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#ff00cc"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+            <path d="M21 3v5h-5" />
+            <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+            <path d="M8 16H3v5" />
+          </svg>
+        </div>
+
         <div
           ref={wrapperRef}
           className="flex h-full"
@@ -481,7 +597,11 @@ export function TaskManager({
           </div>
 
           {/* 中央パネル（現在フィルター） */}
-          <div data-testid="panel-center" style={{ width: "33.333%", height: "100%", overflowY: "auto" }}>
+          <div
+            ref={centerPanelRef}
+            data-testid="panel-center"
+            style={{ width: "33.333%", height: "100%", overflowY: "auto", overscrollBehaviorY: "contain" }}
+          >
             <div className="max-w-2xl mx-auto">
               <TaskListPanel filterKey={center} tasks={taskCache.get(center)} searchQuery={searchQuery} advancedFilter={advancedFilter} sort={sort} onSelect={setSelectedTaskId} />
             </div>

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -220,12 +220,84 @@ describe("スワイプフィルター切り替え", () => {
   })
 
   it("縦スワイプ (dx=30, dy=200) ではフィルターが変わらない", async () => {
+    const { refreshTasksAction } = await import("@/app/actions")
+    vi.mocked(refreshTasksAction).mockClear()
     render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
+    // 中央パネルがスクロール中（scrollTop>0）の状態でテスト：プルも発動せず、フィルター変更も起きない
+    setCenterPanelScrollTop(100)
     act(() => { swipe(getMain(), 30, 200) })
     await act(async () => { vi.runAllTimers() })
     const panel = getCenterPanel()
     expect(within(panel).getByText("進行中タスク")).toBeInTheDocument()
     expect(within(panel).queryByText("確認中タスク")).not.toBeInTheDocument()
+    expect(refreshTasksAction).not.toHaveBeenCalled()
+  })
+})
+
+function setCenterPanelScrollTop(value: number) {
+  Object.defineProperty(getCenterPanel(), "scrollTop", { value, configurable: true, writable: true })
+}
+
+// プル・トゥ・リフレッシュ用：touchMove で full dy を送る（共通 swipe ヘルパーは中間値のみ送るため）
+function pullGesture(el: HTMLElement, dx: number, dy: number) {
+  fireEvent.touchStart(el, { touches: [{ clientX: 0, clientY: 0 }] })
+  fireEvent.touchMove(el, { touches: [{ clientX: dx, clientY: dy }] })
+  fireEvent.touchEnd(el, { changedTouches: [{ clientX: dx, clientY: dy }] })
+}
+
+describe("プル・トゥ・リフレッシュ", () => {
+  beforeEach(async () => {
+    const { refreshTasksAction } = await import("@/app/actions")
+    vi.mocked(refreshTasksAction).mockClear()
+  })
+
+  it("中央パネル最上部から下方向 200px ドラッグで refreshTasksAction が呼ばれる", async () => {
+    const { refreshTasksAction } = await import("@/app/actions")
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
+    setCenterPanelScrollTop(0)
+    act(() => { pullGesture(getMain(), 0, 200) })
+    await waitFor(() => expect(refreshTasksAction).toHaveBeenCalledTimes(1))
+  })
+
+  it("中央パネルがスクロール済み（scrollTop>0）の場合は呼ばれない", async () => {
+    const { refreshTasksAction } = await import("@/app/actions")
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
+    setCenterPanelScrollTop(100)
+    act(() => { pullGesture(getMain(), 0, 200) })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(refreshTasksAction).not.toHaveBeenCalled()
+  })
+
+  it("閾値未満（dy=120、damped=60 < 64）では呼ばれない", async () => {
+    const { refreshTasksAction } = await import("@/app/actions")
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
+    setCenterPanelScrollTop(0)
+    act(() => { pullGesture(getMain(), 0, 120) })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(refreshTasksAction).not.toHaveBeenCalled()
+  })
+
+  it("水平方向が支配的（dx=200, dy=20）なら pull は発動しない", async () => {
+    const { refreshTasksAction } = await import("@/app/actions")
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
+    setCenterPanelScrollTop(0)
+    act(() => { pullGesture(getMain(), 200, 20) })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(refreshTasksAction).not.toHaveBeenCalled()
+  })
+
+  it("詳細ビューが開いている時は呼ばれない", async () => {
+    const { refreshTasksAction } = await import("@/app/actions")
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" initialTaskId="1" />)
+    setCenterPanelScrollTop(0)
+    act(() => { pullGesture(getMain(), 0, 200) })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(refreshTasksAction).not.toHaveBeenCalled()
+  })
+
+  it("プルインジケーターが DOM に存在する", () => {
+    render(<TaskManager tagOptions={[]} initialAdvancedFilter={{ tags: [], dueDate: "any", priorities: [] }} initialSort={DEFAULT_SORT} tasks={tasks} currentFilter="active" />)
+    expect(document.querySelector("[data-testid='pull-indicator']")).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Summary
- タスク一覧の中央パネル最上部から下方向にプルすると、ネオンピンクのインジケーターが追従して引き出され、閾値（プル距離 64px）超過でリリースすると Notion から最新タスクを再取得する。
- 既存の水平スワイプ用方向ロック（`directionRef`）に `"pull"` 状態を追加することで、フィルター切替スワイプ・通常スクロール・詳細ビューのスワイプダウンと衝突しないようにした。
- インジケーターは ref 経由で直接 DOM スタイルを更新するため、毎フレーム再レンダリングが発生しない（既存水平スワイプと同じ手法）。

## Test plan
- [x] ユニットテスト 全 242 件パス（プル・トゥ・リフレッシュ用 6 件追加）
- [x] Playwright テスト 全 35 件パス（`e2e/pull-refresh.spec.ts` 3 件追加、既存縦スワイプテストは scrollTop>0 の条件で更新）
- [ ] モバイル幅でリスト最上部からドラッグして手動確認
  - 64px 超えてリリース → スピナー回転・リスト更新
  - 64px 未満でリリース → インジケーター戻る
  - スクロール下方からの下方向ドラッグ → 通常スクロール
  - 水平スワイプによるフィルター切替が引き続き動く
  - 詳細ビュー開いている状態では発動しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)