### PR TITLE
feat: タスク作成・編集画面から新規タグを追加できるようにする

### DIFF
--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -113,6 +113,29 @@ test.describe("タスク一覧", () => {
     await expect(page.locator("[data-testid='sort-active-dot']")).toHaveCount(0)
   })
 
+  test("作成シートで新規タグを追加するとリストの新タスクに反映される", async ({ page }) => {
+    // 一意な名前で衝突回避（dev モードのストアは pid 単位で永続）
+    const tagName = `e2e-tag-${Date.now()}`
+    const taskName = `タグ追加検証-${tagName}`
+
+    await page.getByRole("button", { name: "タスクを追加" }).click()
+    await expect(page.getByText("✦ New Task")).toBeVisible()
+
+    await page.getByPlaceholder(/TASK NAME/).fill(taskName)
+    await page.getByLabel("新しいタグを追加").fill(tagName)
+    await page.getByRole("button", { name: "タグを追加" }).click()
+
+    // 新タグが選択済みピルとして並ぶ
+    await expect(page.getByRole("button", { name: tagName })).toBeVisible()
+
+    await page.getByRole("button", { name: /CREATE TASK/i }).click()
+
+    // 作成後、リストに当該タスクが現れる
+    const newItem = page.locator(TASK_ITEM, { hasText: taskName })
+    await expect(newItem).toBeVisible({ timeout: 10_000 })
+    await expect(newItem).toContainText(tagName)
+  })
+
   test("ステータスボタンクリックでバッジが楽観的更新される", async ({ page }) => {
     // mock-1 は「未着手」なので「→ 進行中」ボタンが表示される
     const firstItem = page.locator(`${CENTER} ${TASK_ITEM}`).first()

--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -114,7 +114,7 @@ test.describe("タスク一覧", () => {
   })
 
   test("作成シートで新規タグを追加するとリストの新タスクに反映される", async ({ page }) => {
-    // 一意な名前で衝突回避（dev モードのストアは pid 単位で永続）
+    // dev サーバー内のモックストアは複数テスト間で共有されるため、Date.now() で一意化
     const tagName = `e2e-tag-${Date.now()}`
     const taskName = `タグ追加検証-${tagName}`
 

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useState } from "react"
+
+const MAX_TAG_LENGTH = 100
+
+export function TagSelector({
+  options,
+  selected,
+  onChange,
+}: {
+  options: string[]
+  selected: string[]
+  onChange: (next: string[]) => void
+}) {
+  const [draft, setDraft] = useState("")
+
+  const allTags = [...options, ...selected.filter((t) => !options.includes(t))]
+
+  function toggle(tag: string) {
+    onChange(
+      selected.includes(tag) ? selected.filter((t) => t !== tag) : [...selected, tag]
+    )
+  }
+
+  function addTag() {
+    const name = draft.trim()
+    if (!name) return
+    if (name.length > MAX_TAG_LENGTH) return
+    if (name.includes(",")) return
+    if (selected.some((t) => t.toLowerCase() === name.toLowerCase())) {
+      setDraft("")
+      return
+    }
+    const existing = options.find((o) => o.toLowerCase() === name.toLowerCase())
+    onChange([...selected, existing ?? name])
+    setDraft("")
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      addTag()
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2">
+        {allTags.map((tag) => (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => toggle(tag)}
+            className="px-3 py-2 rounded-full text-xs transition-all"
+            style={
+              selected.includes(tag)
+                ? { backgroundColor: "#dc143c", color: "#10000a", border: "1px solid transparent", boxShadow: "0 0 8px rgba(220,20,60,0.5)" }
+                : { backgroundColor: "#10000a", color: "#996677", border: "1px solid rgba(220,20,60,0.2)" }
+            }
+          >
+            {tag}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex gap-2 mt-3">
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="新しいタグ"
+          aria-label="新しいタグを追加"
+          maxLength={MAX_TAG_LENGTH}
+          className="flex-1 min-w-0 rounded-full border border-[rgba(220,20,60,0.3)] px-4 py-2 text-xs text-[#ffbbcc] bg-[#10000a] placeholder:text-[#553344] focus:outline-none focus:border-[#dc143c]"
+          style={{ transition: "border-color 0.2s" }}
+        />
+        <button
+          type="button"
+          onClick={addTag}
+          disabled={!draft.trim()}
+          aria-label="タグを追加"
+          className="px-4 py-2 rounded-full text-xs transition-all disabled:opacity-40"
+          style={{ backgroundColor: "#dc143c", color: "#10000a" }}
+        >
+          +
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { PILL_BUTTON_CLASS, pillButtonStyle } from "@/constants/styles"
 
 const MAX_TAG_LENGTH = 100
 
@@ -52,12 +53,8 @@ export function TagSelector({
             key={tag}
             type="button"
             onClick={() => toggle(tag)}
-            className="px-3 py-2 rounded-full text-xs transition-all"
-            style={
-              selected.includes(tag)
-                ? { backgroundColor: "#dc143c", color: "#10000a", border: "1px solid transparent", boxShadow: "0 0 8px rgba(220,20,60,0.5)" }
-                : { backgroundColor: "#10000a", color: "#996677", border: "1px solid rgba(220,20,60,0.2)" }
-            }
+            className={PILL_BUTTON_CLASS}
+            style={pillButtonStyle(selected.includes(tag))}
           >
             {tag}
           </button>

--- a/src/components/TaskCreate.tsx
+++ b/src/components/TaskCreate.tsx
@@ -5,6 +5,7 @@ import { useFormStatus } from "react-dom"
 import { createTaskAction } from "@/app/actions"
 import { buildDue } from "@/lib/due-date"
 import { DueDateTimeInput } from "./DueDateTimeInput"
+import { TagSelector } from "./TagSelector"
 import type { TaskStatus, TaskPriority } from "@/types/task"
 
 function SubmitButton() {
@@ -39,12 +40,6 @@ export function TaskCreate({ tagOptions }: { tagOptions: string[] }) {
     document.body.style.overflow = "hidden"
     return () => { document.body.style.overflow = prev }
   }, [open])
-
-  function toggleTag(tag: string) {
-    setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-    )
-  }
 
   function handleOpen() {
     setSelectedTags([])
@@ -173,23 +168,7 @@ export function TaskCreate({ tagOptions }: { tagOptions: string[] }) {
 
               <div>
                 <p className="text-xs text-[#996677] mb-2 tracking-widest uppercase">タグ</p>
-                <div className="flex flex-wrap gap-2">
-                  {tagOptions.map((tag) => (
-                    <button
-                      key={tag}
-                      type="button"
-                      onClick={() => toggleTag(tag)}
-                      className="px-3 py-2 rounded-full text-xs transition-all"
-                      style={
-                        selectedTags.includes(tag)
-                          ? { backgroundColor: "#dc143c", color: "#10000a", border: "1px solid transparent", boxShadow: "0 0 8px rgba(220,20,60,0.5)" }
-                          : { backgroundColor: "#10000a", color: "#996677", border: "1px solid rgba(220,20,60,0.2)" }
-                      }
-                    >
-                      {tag}
-                    </button>
-                  ))}
-                </div>
+                <TagSelector options={tagOptions} selected={selectedTags} onChange={setSelectedTags} />
               </div>
 
               <SubmitButton />

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -7,6 +7,7 @@ import { STATUS_OPTIONS, STATUS_STYLES } from "@/constants/styles"
 import { MarkdownPreview } from "./MarkdownPreview"
 import { parseDue, buildDue, snapTimeTo5Min, formatDueShort } from "@/lib/due-date"
 import { DueDateTimeInput } from "./DueDateTimeInput"
+import { TagSelector } from "./TagSelector"
 
 export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptions: string[]; onClose: () => void }) {
   const [, startTransition] = useTransition()
@@ -275,10 +276,7 @@ export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptio
     save({ due: buildDue(date, time) })
   }
 
-  function toggleTag(tag: string) {
-    const next = editTags.includes(tag)
-      ? editTags.filter((t) => t !== tag)
-      : [...editTags, tag]
+  function handleTagsChange(next: string[]) {
     setEditTags(next)
     save({ tags: next })
   }
@@ -370,23 +368,7 @@ export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptio
           </Row>
 
           <Row label="タグ">
-            <div className="flex flex-wrap gap-2">
-              {tagOptions.map((tag) => (
-                <button
-                  key={tag}
-                  type="button"
-                  onClick={() => toggleTag(tag)}
-                  className="px-3 py-2 rounded-full text-xs transition-all"
-                  style={
-                    editTags.includes(tag)
-                      ? { backgroundColor: "#dc143c", color: "#10000a", border: "1px solid transparent", boxShadow: "0 0 8px rgba(220,20,60,0.5)" }
-                      : { backgroundColor: "#10000a", color: "#996677", border: "1px solid rgba(220,20,60,0.2)" }
-                  }
-                >
-                  {tag}
-                </button>
-              ))}
-            </div>
+            <TagSelector options={tagOptions} selected={editTags} onChange={handleTagsChange} />
           </Row>
 
           {task.source && (

--- a/src/components/TaskFilterSheet.tsx
+++ b/src/components/TaskFilterSheet.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import type { AdvancedFilter, DueDateMode, TaskPriority } from "@/types/task"
 import { DEFAULT_ADVANCED_FILTER } from "@/constants/filters"
-import { PRIORITY_STYLES } from "@/constants/styles"
+import { PRIORITY_STYLES, PILL_BUTTON_CLASS, pillButtonStyle } from "@/constants/styles"
 
 const DUE_OPTIONS: { value: DueDateMode; label: string }[] = [
   { value: "any",     label: "不問" },
@@ -96,12 +96,8 @@ export function TaskFilterSheet({
                     key={tag}
                     type="button"
                     onClick={() => toggleTag(tag)}
-                    className="px-3 py-2 rounded-full text-xs transition-all"
-                    style={
-                      draft.tags.includes(tag)
-                        ? { backgroundColor: "#dc143c", color: "#10000a", border: "1px solid transparent", boxShadow: "0 0 8px rgba(220,20,60,0.5)" }
-                        : { backgroundColor: "#10000a", color: "#996677", border: "1px solid rgba(220,20,60,0.2)" }
-                    }
+                    className={PILL_BUTTON_CLASS}
+                    style={pillButtonStyle(draft.tags.includes(tag))}
                   >
                     {tag}
                   </button>
@@ -123,12 +119,8 @@ export function TaskFilterSheet({
                     data-testid={`due-${opt.value}`}
                     aria-pressed={active}
                     onClick={() => setDue(opt.value)}
-                    className="px-3 py-2 rounded-full text-xs transition-all"
-                    style={
-                      active
-                        ? { backgroundColor: "#dc143c", color: "#10000a", border: "1px solid transparent", boxShadow: "0 0 8px rgba(220,20,60,0.5)" }
-                        : { backgroundColor: "#10000a", color: "#996677", border: "1px solid rgba(220,20,60,0.2)" }
-                    }
+                    className={PILL_BUTTON_CLASS}
+                    style={pillButtonStyle(active)}
                   >
                     {opt.label}
                   </button>
@@ -149,12 +141,8 @@ export function TaskFilterSheet({
                     type="button"
                     data-testid={`priority-${p}`}
                     onClick={() => togglePriority(p)}
-                    className="px-3 py-2 rounded-full text-xs transition-all"
-                    style={
-                      active
-                        ? { backgroundColor: "#dc143c", color: "#10000a", border: "1px solid transparent", boxShadow: "0 0 8px rgba(220,20,60,0.5)" }
-                        : { backgroundColor: "#10000a", color: "#996677", border: "1px solid rgba(220,20,60,0.2)" }
-                    }
+                    className={PILL_BUTTON_CLASS}
+                    style={pillButtonStyle(active)}
                   >
                     {PRIORITY_STYLES[p].label}
                   </button>

--- a/src/components/__tests__/TagSelector.test.tsx
+++ b/src/components/__tests__/TagSelector.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { TagSelector } from "@/components/TagSelector"
+
+const OPTIONS = ["Tech", "Blog", "Operation"]
+
+describe("TagSelector ピル", () => {
+  it("候補タグを全て描画する", () => {
+    render(<TagSelector options={OPTIONS} selected={[]} onChange={() => {}} />)
+    for (const tag of OPTIONS) {
+      expect(screen.getByRole("button", { name: tag })).toBeInTheDocument()
+    }
+  })
+
+  it("選択済みタグはアクセント色で描画される", () => {
+    render(<TagSelector options={OPTIONS} selected={["Tech"]} onChange={() => {}} />)
+    expect(screen.getByRole("button", { name: "Tech" })).toHaveStyle({ backgroundColor: "#dc143c" })
+  })
+
+  it("候補にない選択済みタグもピルとして描画される", () => {
+    render(<TagSelector options={OPTIONS} selected={["カスタム"]} onChange={() => {}} />)
+    expect(screen.getByRole("button", { name: "カスタム" })).toBeInTheDocument()
+  })
+
+  it("ピルクリックで選択を追加する", () => {
+    const onChange = vi.fn()
+    render(<TagSelector options={OPTIONS} selected={[]} onChange={onChange} />)
+    fireEvent.click(screen.getByRole("button", { name: "Tech" }))
+    expect(onChange).toHaveBeenCalledWith(["Tech"])
+  })
+
+  it("選択済みピルクリックで選択を解除する", () => {
+    const onChange = vi.fn()
+    render(<TagSelector options={OPTIONS} selected={["Tech", "Blog"]} onChange={onChange} />)
+    fireEvent.click(screen.getByRole("button", { name: "Tech" }))
+    expect(onChange).toHaveBeenCalledWith(["Blog"])
+  })
+})
+
+describe("TagSelector 新規追加", () => {
+  it("入力 + 追加ボタンで新タグを onChange に渡す", () => {
+    const onChange = vi.fn()
+    render(<TagSelector options={OPTIONS} selected={["Tech"]} onChange={onChange} />)
+
+    const input = screen.getByLabelText("新しいタグを追加")
+    fireEvent.change(input, { target: { value: "新タグ" } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+
+    expect(onChange).toHaveBeenCalledWith(["Tech", "新タグ"])
+  })
+
+  it("Enter キーで新タグを追加する", () => {
+    const onChange = vi.fn()
+    render(<TagSelector options={OPTIONS} selected={[]} onChange={onChange} />)
+
+    const input = screen.getByLabelText("新しいタグを追加")
+    fireEvent.change(input, { target: { value: "新タグ" } })
+    fireEvent.keyDown(input, { key: "Enter" })
+
+    expect(onChange).toHaveBeenCalledWith(["新タグ"])
+  })
+
+  it("追加成功後に入力欄がクリアされる", () => {
+    render(<TagSelector options={OPTIONS} selected={[]} onChange={() => {}} />)
+    const input = screen.getByLabelText("新しいタグを追加") as HTMLInputElement
+    fireEvent.change(input, { target: { value: "新タグ" } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+    expect(input.value).toBe("")
+  })
+
+  it("空入力では onChange は呼ばれない", () => {
+    const onChange = vi.fn()
+    render(<TagSelector options={OPTIONS} selected={[]} onChange={onChange} />)
+
+    const input = screen.getByLabelText("新しいタグを追加")
+    fireEvent.change(input, { target: { value: "   " } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("カンマを含む名前は拒否される", () => {
+    const onChange = vi.fn()
+    render(<TagSelector options={OPTIONS} selected={[]} onChange={onChange} />)
+
+    const input = screen.getByLabelText("新しいタグを追加")
+    fireEvent.change(input, { target: { value: "a,b" } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("既に選択済みのタグは追加せず入力をクリアする", () => {
+    const onChange = vi.fn()
+    render(<TagSelector options={OPTIONS} selected={["Tech"]} onChange={onChange} />)
+
+    const input = screen.getByLabelText("新しいタグを追加") as HTMLInputElement
+    fireEvent.change(input, { target: { value: "tech" } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.value).toBe("")
+  })
+
+  it("候補と同名（大小無視）の入力は既存名でトグルされる", () => {
+    const onChange = vi.fn()
+    render(<TagSelector options={OPTIONS} selected={[]} onChange={onChange} />)
+
+    const input = screen.getByLabelText("新しいタグを追加")
+    fireEvent.change(input, { target: { value: "tech" } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+
+    expect(onChange).toHaveBeenCalledWith(["Tech"])
+  })
+})

--- a/src/components/__tests__/TaskCreate.test.tsx
+++ b/src/components/__tests__/TaskCreate.test.tsx
@@ -91,6 +91,43 @@ describe("TaskCreate タグトグル", () => {
     expect(screen.getByRole("button", { name: "Tech" })).toHaveStyle({ backgroundColor: "#dc143c" })
     expect(screen.getByRole("button", { name: "Blog" })).toHaveStyle({ backgroundColor: "#dc143c" })
   })
+
+  it("新規タグを入力して追加すると選択済みピルとして並ぶ", () => {
+    fireEvent.change(screen.getByLabelText("新しいタグを追加"), { target: { value: "新タグ" } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+
+    const newPill = screen.getByRole("button", { name: "新タグ" })
+    expect(newPill).toBeInTheDocument()
+    expect(newPill).toHaveStyle({ backgroundColor: "#dc143c" })
+  })
+})
+
+describe("TaskCreate 新規タグを送信", () => {
+  beforeEach(() => {
+    render(<TaskCreate tagOptions={TAG_OPTIONS} />)
+    fireEvent.click(screen.getByRole("button", { name: "タスクを追加" }))
+  })
+
+  it("新規タグを追加して送信すると tags に含まれる", async () => {
+    const { createTaskAction } = await import("@/app/actions")
+    const mock = vi.mocked(createTaskAction)
+    mock.mockClear()
+
+    fireEvent.change(screen.getByLabelText("新しいタグを追加"), { target: { value: "新タグ" } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+
+    const titleInput = screen.getByPlaceholderText(/TASK NAME/)
+    fireEvent.change(titleInput, { target: { value: "タスクB" } })
+
+    const form = titleInput.closest("form") as HTMLFormElement
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "タスクB", tags: ["新タグ"] })
+      )
+    })
+  })
 })
 
 describe("TaskCreate バックドロップで閉じる", () => {

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -232,6 +232,19 @@ describe("TaskDetail フィールド変更", () => {
     })
   })
 
+  it("新規タグを追加すると updateTaskAction に新タグ入りで送られる", async () => {
+    const mock = vi.mocked(updateTaskAction)
+    mock.mockClear()
+
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", tags: [] })} onClose={() => {}} />)
+    fireEvent.change(screen.getByLabelText("新しいタグを追加"), { target: { value: "新タグ" } })
+    fireEvent.click(screen.getByRole("button", { name: "タグを追加" }))
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith("t1", { tags: ["新タグ"] })
+    })
+  })
+
   it("時刻入力で updateTaskAction に時刻入り due が渡る", async () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -19,3 +19,11 @@ export const PRIORITY_STYLES: Record<TaskPriority, { label: string; color: strin
   medium: { label: "⚠️ Med",  color: "text-[#ffaa00]" },
   low:    { label: "💤 Low",  color: "text-[#00ffcc]" },
 }
+
+export const PILL_BUTTON_CLASS = "px-3 py-2 rounded-full text-xs transition-all"
+
+export function pillButtonStyle(selected: boolean) {
+  return selected
+    ? { backgroundColor: "#dc143c", color: "#10000a", border: "1px solid transparent", boxShadow: "0 0 8px rgba(220,20,60,0.5)" }
+    : { backgroundColor: "#10000a", color: "#996677", border: "1px solid rgba(220,20,60,0.2)" }
+}

--- a/src/lib/mock-tasks.ts
+++ b/src/lib/mock-tasks.ts
@@ -249,8 +249,11 @@ export function addMockTaskComment(id: string, text: string): TaskComment {
   return comment
 }
 
+const SEED_TAG_OPTIONS = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
+
 export function getMockTagOptions(): string[] {
-  return ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
+  const fromStore = store.flatMap((t) => t.tags)
+  return Array.from(new Set([...SEED_TAG_OPTIONS, ...fromStore]))
 }
 
 export function updateMockTask(id: string, input: UpdateTaskInput): Task | null {


### PR DESCRIPTION
## Summary
- タスク作成シートとタスク詳細シートのタグ欄に「新しいタグ」入力フィールドと `+` ボタンを追加。Enter キーでも追加可能。
- 既存ピル UI と新規入力 UI を `TagSelector` コンポーネントに集約し、両画面で再利用。
- 未知のタグ名を渡した場合、Notion multi_select はオプションを自動追加するため、バックエンド (`createTask` / `updateTask`) は変更不要。
- dev / E2E 用に `getMockTagOptions()` をストアから動的に算出するよう更新（追加した新タグが次回以降の候補にも並ぶ）。

## バリデーション
- 空文字 / 前後空白のみは無視
- カンマを含む名前は拒否（Notion multi_select の制約）
- 100 文字超は拒否
- 既選択と同名（大小無視）は再追加せず入力をクリア
- 候補と同名（大小無視）は既存名でトグル

## Test plan
- [x] `npm run test:unit` — 257 tests pass（うち TagSelector の新規 11 件を含む）
- [x] `npx playwright test` — 37 tests pass（新規 E2E「作成シートで新規タグを追加するとリストの新タスクに反映される」を含む）
- [ ] dev サーバーで作成シート → 新タグ入力 → 追加 → 作成 → リストに反映を目視確認
- [ ] dev サーバーで詳細シート → 新タグ入力 → 追加（即時保存） → 再度開いて反映確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)