### PR TITLE
fix: タスク編集画面でタグ追加ボタンが見切れる問題と + アイコンの視認性を修正

### DIFF
--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -70,7 +70,7 @@ export function TagSelector({
           placeholder="新しいタグ"
           aria-label="新しいタグを追加"
           maxLength={MAX_TAG_LENGTH}
-          className="flex-1 min-w-0 rounded-full border border-[rgba(220,20,60,0.3)] px-4 py-2 text-xs text-[#ffbbcc] bg-[#10000a] placeholder:text-[#553344] focus:outline-none focus:border-[#dc143c]"
+          className="flex-1 min-w-0 h-9 rounded-full border border-[rgba(220,20,60,0.3)] px-4 text-xs text-[#ffbbcc] bg-[#10000a] placeholder:text-[#553344] focus:outline-none focus:border-[#dc143c]"
           style={{ transition: "border-color 0.2s" }}
         />
         <button
@@ -78,10 +78,13 @@ export function TagSelector({
           onClick={addTag}
           disabled={!draft.trim()}
           aria-label="タグを追加"
-          className="px-4 py-2 rounded-full text-xs transition-all disabled:opacity-40"
+          className="flex-shrink-0 w-9 h-9 rounded-full flex items-center justify-center transition-all disabled:opacity-40"
           style={{ backgroundColor: "#dc143c", color: "#10000a" }}
         >
-          +
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
         </button>
       </div>
     </div>

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -559,7 +559,7 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
   return (
     <div className="flex gap-3">
       <span className="text-xs text-[#553344] w-16 flex-shrink-0 pt-1 tracking-wide">{label}</span>
-      <div className="flex-1">{children}</div>
+      <div className="flex-1 min-w-0">{children}</div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- タスク編集画面（`TaskDetail`）でタグ追加ボタンが画面右端から見切れていた問題を修正。`Row` の `flex-1` 子要素に `min-w-0` を追加し、`TagSelector` の入力行が親幅に収まるようにした。
- `+` テキストアイコンが `text-xs` (12px) でボタンに対して小さすぎたため、FAB と同デザインの 16×16 SVG アイコンに置き換え、ボタンを 36×36 円形に統一。入力欄も `h-9` で揃えて視覚的に整列。

## Test plan
- [x] `npm run test:unit` — 257 tests pass
- [x] `npx playwright test` — 37 tests pass
- [ ] dev サーバーの iPhone ビューでタスク詳細を開き、タグ追加ボタンが画面内に収まり、+ アイコンが視認しやすいサイズになっていることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)