### PR TITLE
feat: タスク一覧画面が再表示されたら自動で最新化する

### DIFF
--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -213,6 +213,17 @@ export function TaskManager({
   useEffect(() => { selectedTaskIdRef.current = selectedTaskId }, [selectedTaskId])
   useEffect(() => { isPendingRef.current = isPending }, [isPending])
 
+  // ─── Refresh on visibility change ─────────────────────────────────────────
+  useEffect(() => {
+    function onVisible() {
+      if (document.visibilityState !== "visible") return
+      if (isPendingRef.current) return
+      startTransition(async () => { await refreshTasksAction() })
+    }
+    document.addEventListener("visibilitychange", onVisible)
+    return () => document.removeEventListener("visibilitychange", onVisible)
+  }, [])
+
   // ─── Swipe gesture ────────────────────────────────────────────────────────
   useEffect(() => {
     const el = mainRef.current


### PR DESCRIPTION
## Summary
- `TaskManager` に `visibilitychange` リスナーを追加し、画面が可視状態に戻るたびに `refreshTasksAction` を呼んでタスク一覧を自動で再取得するようにした
- 既存の pull-to-refresh / 更新ボタンと同様に、`isPending` 中は二重発火しないようガードしている

## Why
PWA をフォアグラウンドに復帰させたり、別タブから戻ってきた際にタスク一覧が古いままになり、毎回手動でリフレッシュする必要があった。

## Test plan
- [x] `npm run test:unit` (257 passed)
- [x] `npx playwright test` (39 passed)
- [ ] PWA をホームに送って戻したときに、タスク一覧がスピナーと共に最新化されること
- [ ] 別タブに切り替えて戻ったときに、タスク一覧が最新化されること
- [ ] タスク詳細を開いた状態で戻ってきても二重発火せず、詳細表示も壊れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)