### PR TITLE
feat: iOS PWA メタとオフラインフォールバックを追加

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,7 @@
-const CACHE_NAME = "notion-tasks-v2"
-const STATIC_CACHE_NAME = "notion-tasks-static-v2"
+const CACHE_NAME = "notion-tasks-v3"
+const STATIC_CACHE_NAME = "notion-tasks-static-v3"
+
+const OFFLINE_URL = "/offline"
 
 // Static assets that can be cached long-term (content-hashed filenames)
 const STATIC_ORIGINS_PATTERNS = [
@@ -9,7 +11,9 @@ const STATIC_ORIGINS_PATTERNS = [
 
 self.addEventListener("install", (event) => {
   self.skipWaiting()
-  event.waitUntil(caches.open(STATIC_CACHE_NAME))
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.add(new Request(OFFLINE_URL, { cache: "reload" })))
+  )
 })
 
 self.addEventListener("activate", (event) => {
@@ -47,7 +51,7 @@ self.addEventListener("fetch", (event) => {
     return
   }
 
-  // Network-first for navigation: always fetch fresh HTML, fall back to cache when offline
+  // Network-first for navigation: always fetch fresh HTML, fall back to cache, then to /offline when offline
   if (request.mode === "navigate") {
     event.respondWith(
       caches.open(CACHE_NAME).then(async (cache) => {
@@ -56,7 +60,11 @@ self.addEventListener("fetch", (event) => {
           if (res.ok) cache.put(request, res.clone())
           return res
         } catch {
-          return (await cache.match(request)) ?? Response.error()
+          const cached = await cache.match(request)
+          if (cached) return cached
+          const offline = await cache.match(OFFLINE_URL)
+          if (offline) return offline
+          return Response.error()
         }
       })
     )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,11 @@ const dotGothic = DotGothic16({
 export const metadata: Metadata = {
   title: "To-do",
   description: "Notion タスク管理",
+  appleWebApp: {
+    capable: true,
+    title: "To-do",
+    statusBarStyle: "black-translucent",
+  },
 }
 
 export const viewport: Viewport = {

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = "force-static"
+
+export default function OfflinePage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full px-8 text-center">
+      <div className="text-[#dc143c] text-2xl font-bold tracking-[0.3em] mb-8 cyber-glow-text">
+        ✦ OFFLINE
+      </div>
+      <p className="text-sm text-[#ffbbcc] tracking-widest mb-4">
+        — NETWORK UNREACHABLE —
+      </p>
+      <p className="text-xs text-[#996677] leading-relaxed max-w-xs">
+        ネットワーク接続を確認してから、もう一度開き直してください。
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `layout.tsx` の `metadata.appleWebApp` を追加し、iOS ホーム画面追加時に standalone 表示・ステータスバースタイル・アプリ名を反映
- `/offline` 静的ページを新設し、Service Worker の install 時に precache
- ナビゲーション fetch が失敗したときの最終フォールバックとして `/offline` を返すよう SW を更新（cache 名は v3 に bump）

## Why
- iOS PWA でメタが無く Safari chrome が混ざる standalone 体験になっていた
- 未訪問ページにオフラインで遷移するとブラウザ素のオフライン画面が出ていた

## Test plan
- [x] `npm run test:unit` (257 passed)
- [x] `npx playwright test` (39 passed)
- [ ] iPhone 実機でホーム画面追加 → 起動時に Safari の URL バーが消えること（standalone）
- [ ] DevTools > Application > Service Workers で update し、Offline チェック → 任意の URL で `/offline` ページが表示されること
- [ ] 既訪問ページはオフラインでもキャッシュから表示されること（既存挙動の維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)