### PR TITLE
feat: PWA まわりの仕上げ（manifest 補強・viewport a11y・アイコン静的化）

### DIFF
--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -3,6 +3,7 @@ import { cyberIconJsx } from "@/lib/cyber-icon-jsx"
 
 export const size = { width: 180, height: 180 }
 export const contentType = "image/png"
+export const dynamic = "force-static"
 
 export default function AppleIcon() {
   return new ImageResponse(cyberIconJsx(180), { width: 180, height: 180 })

--- a/src/app/icon-192/route.ts
+++ b/src/app/icon-192/route.ts
@@ -1,6 +1,8 @@
 import { ImageResponse } from "next/og"
 import { cyberIconJsx } from "@/lib/cyber-icon-jsx"
 
+export const dynamic = "force-static"
+
 export function GET() {
   return new ImageResponse(cyberIconJsx(192), { width: 192, height: 192 })
 }

--- a/src/app/icon-512/route.ts
+++ b/src/app/icon-512/route.ts
@@ -1,6 +1,8 @@
 import { ImageResponse } from "next/og"
 import { cyberIconJsx } from "@/lib/cyber-icon-jsx"
 
+export const dynamic = "force-static"
+
 export function GET() {
   return new ImageResponse(cyberIconJsx(512), { width: 512, height: 512 })
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,8 +25,6 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
   colorScheme: "dark",
   themeColor: "#dc143c",
 }

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -2,11 +2,17 @@ import type { MetadataRoute } from "next"
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
+    id: "/",
     name: "To-do",
     short_name: "To-do",
     description: "Notion タスク管理",
     start_url: "/",
+    scope: "/",
     display: "standalone",
+    orientation: "portrait",
+    lang: "ja",
+    dir: "ltr",
+    categories: ["productivity"],
     background_color: "#10000a",
     theme_color: "#dc143c",
     icons: [


### PR DESCRIPTION
## Summary
- `manifest.ts` に `id`, `scope`, `lang`, `dir`, `orientation`, `categories` を追加
- `viewport` から `maximumScale: 1` と `userScalable: false` を削除（Android でのピンチズーム禁止を解消）
- `/icon-192`, `/icon-512`, `apple-icon` を `dynamic = "force-static"` でビルド時プリレンダリング

## Why
PR #62 の議論で出た PWA 最適化の残課題（gap 3〜5）の解消。インストール識別性・a11y・初回起動レイテンシをまとめて改善する小さな変更群。

## 注意点
- スワイプジェスチャ実装は多指タッチ時に縦スクロール扱いに落とすため、ピンチズーム解禁による回帰は無いはず
- `screenshots` と `shortcuts` は本対応に含めていない（前者は実画像、後者は別途ディープリンク設計が必要）

## Test plan
- [x] `npm run test:unit` (257 passed)
- [x] `npx playwright test` (39 passed)
- [ ] Chrome DevTools > Application > Manifest で id/scope/categories 等が表示されること
- [ ] 二本指ピンチでズームができること（Android 実機 or DevTools のタッチエミュレーション）
- [ ] `/icon-192`, `/icon-512`, `/apple-icon` の Network タブで `200 (from disk cache)` 等のキャッシュヒットが発生すること（2 回目以降）

🤖 Generated with [Claude Code](https://claude.com/claude-code)