### PR TITLE
perf(e2e): networkidle 撤廃 + ハイドレーション待ち導入で 13% 短縮

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -17,9 +17,18 @@ export async function resetMockStore(page: Page) {
   await page.request.get("/api/dev/reset")
 }
 
+export async function waitForHydration(page: Page) {
+  await page.waitForFunction(
+    () => document.documentElement.dataset.hydrated === "1",
+    null,
+    { timeout: 5_000 },
+  )
+}
+
 export async function resetAndOpenHome(page: Page) {
   await setDefaultCookies(page.context())
   await resetMockStore(page)
   await page.goto("/")
   await expect(page.locator(`${CENTER} ${TASK_ITEM}`).first()).toBeVisible({ timeout: 15_000 })
+  await waitForHydration(page)
 }

--- a/e2e/pull-refresh.spec.ts
+++ b/e2e/pull-refresh.spec.ts
@@ -1,19 +1,10 @@
 import { test, expect } from "@playwright/test"
-import type { Page, CDPSession } from "@playwright/test"
+import type { CDPSession, Page } from "@playwright/test"
+import { resetAndOpenHome } from "./helpers"
 
 test.use({ storageState: "e2e/.auth/user.json" })
 
-const CENTER = "[data-testid='panel-center']"
-const TASK_ITEM = "[data-testid='task-item']"
 const PULL_INDICATOR = "[data-testid='pull-indicator']"
-
-async function resetAndWait(page: Page) {
-  await page.context().addCookies([{ name: "filter", value: "active", domain: "localhost", path: "/" }])
-  await page.request.get("/api/dev/reset")
-  await page.goto("/")
-  await expect(page.locator(`${CENTER} ${TASK_ITEM}`).first()).toBeVisible({ timeout: 15_000 })
-  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {})
-}
 
 async function swipe(cdp: CDPSession, sx: number, sy: number, dx: number, dy = 0) {
   const STEPS = 8
@@ -44,7 +35,7 @@ test.describe("プル・トゥ・リフレッシュ", () => {
   test.describe.configure({ mode: "serial" })
 
   test.beforeEach(async ({ page }) => {
-    await resetAndWait(page)
+    await resetAndOpenHome(page)
   })
 
   test("インジケーターが DOM に存在する", async ({ page }) => {

--- a/e2e/snapshot.spec.ts
+++ b/e2e/snapshot.spec.ts
@@ -1,18 +1,11 @@
 import { test, expect } from "@playwright/test"
+import { CENTER, resetAndOpenHome } from "./helpers"
 
 test.use({ storageState: "e2e/.auth/user.json" })
 
-const CENTER = "[data-testid='panel-center']"
-
 test.describe("視覚回帰", () => {
   test.beforeEach(async ({ page }) => {
-    await page.context().addCookies([
-      { name: "filter", value: "active", domain: "localhost", path: "/" },
-      { name: "sort",   value: JSON.stringify({ key: "default", direction: "asc" }), domain: "localhost", path: "/" },
-    ])
-    await page.request.get("/api/dev/reset")
-    await page.goto("/")
-    await page.locator(`${CENTER} [data-testid='task-item']`).first().waitFor({ state: "visible", timeout: 15_000 })
+    await resetAndOpenHome(page)
   })
 
   test("home: filter=active", async ({ page }) => {

--- a/e2e/swipe.spec.ts
+++ b/e2e/swipe.spec.ts
@@ -1,20 +1,8 @@
 import { test, expect } from "@playwright/test"
 import type { Page, CDPSession } from "@playwright/test"
+import { CENTER, TASK_ITEM, resetAndOpenHome } from "./helpers"
 
 test.use({ storageState: "e2e/.auth/user.json" })
-
-const CENTER = "[data-testid='panel-center']"
-const TASK_ITEM = "[data-testid='task-item']"
-
-async function resetAndWait(page: Page) {
-  await page.context().addCookies([{ name: "filter", value: "active", domain: "localhost", path: "/" }])
-  await page.request.get("/api/dev/reset")
-  await page.goto("/")
-  await expect(page.locator(`${CENTER} ${TASK_ITEM}`).first()).toBeVisible({ timeout: 15_000 })
-  // 隣接パネル（左右フィルター）のプリフェッチ完了を待つ。
-  // バックグラウンドリクエストが詰まっても永遠に待たないよう timeout を明示する。
-  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {})
-}
 
 // CDP Input.dispatchTouchEvent でスワイプをシミュレート（Chromium のみ）
 async function swipe(cdp: CDPSession, sx: number, sy: number, dx: number, dy = 0) {
@@ -45,7 +33,7 @@ test.describe("スワイプナビゲーション", () => {
   test.describe.configure({ mode: "serial" })
 
   test.beforeEach(async ({ page }) => {
-    await resetAndWait(page)
+    await resetAndOpenHome(page)
   })
 
   test("左スワイプでフィルターが次に進む (active → todo)", async ({ page, context }) => {

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -130,6 +130,11 @@ export function TaskManager({
   initialSort: SortConfig
   initialTaskId?: string | null
 }) {
+  // E2E 用にハイドレーション完了を <html data-hydrated="1"> でマーキングする
+  useEffect(() => {
+    document.documentElement.dataset.hydrated = "1"
+  }, [])
+
   const [advancedFilter, setAdvancedFilter] = useState<AdvancedFilter>(initialAdvancedFilter)
   const [sort, setSort] = useState<SortConfig>(initialSort)
   const [filterSheetOpen, setFilterSheetOpen] = useState(false)


### PR DESCRIPTION
## Summary
- TaskManager にハイドレーション完了マーカー（`<html data-hydrated="1">`）を仕込む `useEffect` を追加
- `resetAndOpenHome` で task-item 可視確認後に `waitForHydration` を呼び、SSR 直後にクリックして optimistic update が空振りする flake を防止
- `swipe.spec.ts` / `pull-refresh.spec.ts` / `snapshot.spec.ts` の重複 `resetAndWait` を `e2e/helpers.ts` に集約し、`waitForLoadState("networkidle")` を撤廃（隣接パネルのプリフェッチ完了は実アサーションには不要）

## 実測効果
- 全体: 90.0s → **78.0s（-13%）**
- 累計（baseline 121.1s 比）: **-36%**
- 前 PR で 1 件発生していた flaky（Desktop Chrome の楽観的ステータス更新）が解消し **flake=0**

| spec | 90s 時点 | 78s 時点 |
|---|---:|---:|
| tasks.spec.ts | 27.3s | 19.3s |
| task-detail.spec.ts | 11.5s | 8.9s |
| swipe.spec.ts | 11.0s | 8.9s |
| pull-refresh.spec.ts | 6.5s | 5.1s |
| snapshot.spec.ts | 13.2s | 12.3s |

## Test plan
- [x] `npm run test:unit` 257 passed
- [x] `npx playwright test` 39 passed / 0 flaky / 78s（直列・workers=1 維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)