### PR TITLE
feat: iOS PWA スプラッシュ画像と SW 更新通知 UI を追加

### DIFF
--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -28,3 +28,37 @@ test.describe("PWA マニフェスト", () => {
     expect(response.headers()["content-type"]).toContain("image/png")
   })
 })
+
+test.describe("iOS PWA スプラッシュ", () => {
+  test("/splash/750x1334 が PNG を返す", async ({ request }) => {
+    const response = await request.get("/splash/750x1334")
+    expect(response.status()).toBe(200)
+    expect(response.headers()["content-type"]).toContain("image/png")
+  })
+
+  test("/splash/1290x2796 が PNG を返す", async ({ request }) => {
+    const response = await request.get("/splash/1290x2796")
+    expect(response.status()).toBe(200)
+    expect(response.headers()["content-type"]).toContain("image/png")
+  })
+
+  test("apple-touch-startup-image link が複数登録されている", async ({ page }) => {
+    await page.goto("/")
+    const count = await page.locator('link[rel="apple-touch-startup-image"]').count()
+    expect(count).toBeGreaterThanOrEqual(5)
+
+    const first = await page.locator('link[rel="apple-touch-startup-image"]').first()
+    expect(await first.getAttribute("href")).toMatch(/\/splash\/\d+x\d+/)
+    expect(await first.getAttribute("media")).toContain("device-width")
+  })
+})
+
+test.describe("Service Worker", () => {
+  test("/sw.js が SKIP_WAITING メッセージを受け付ける", async ({ request }) => {
+    const response = await request.get("/sw.js")
+    expect(response.status()).toBe(200)
+    const body = await response.text()
+    expect(body).toContain("SKIP_WAITING")
+    expect(body).toContain("addEventListener(\"message\"")
+  })
+})

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
-const CACHE_NAME = "notion-tasks-v3"
-const STATIC_CACHE_NAME = "notion-tasks-static-v3"
+const CACHE_NAME = "notion-tasks-v4"
+const STATIC_CACHE_NAME = "notion-tasks-static-v4"
 
 const OFFLINE_URL = "/offline"
 
@@ -9,11 +9,16 @@ const STATIC_ORIGINS_PATTERNS = [
   /\/icons\//,
 ]
 
+// install では skipWaiting しない: 既存タブが操作中に SW が切り替わるのを防ぎ、
+// クライアント側 UI でユーザーが「更新」を押したタイミングで SKIP_WAITING を受けて切り替える
 self.addEventListener("install", (event) => {
-  self.skipWaiting()
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.add(new Request(OFFLINE_URL, { cache: "reload" })))
   )
+})
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") self.skipWaiting()
 })
 
 self.addEventListener("activate", (event) => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next"
 import { DotGothic16 } from "next/font/google"
 import ServiceWorkerRegistration from "@/components/ServiceWorkerRegistration"
 import { SplashScreen } from "@/components/SplashScreen"
+import { splashStartupImages } from "@/constants/splash"
 import "./globals.css"
 
 const dotGothic = DotGothic16({
@@ -19,6 +20,7 @@ export const metadata: Metadata = {
     capable: true,
     title: "To-do",
     statusBarStyle: "black-translucent",
+    startupImage: splashStartupImages(),
   },
 }
 

--- a/src/app/splash/[size]/route.ts
+++ b/src/app/splash/[size]/route.ts
@@ -1,0 +1,17 @@
+import { ImageResponse } from "next/og"
+import { splashJsx } from "@/lib/splash-jsx"
+import { SPLASH_SIZES } from "@/constants/splash"
+
+export const dynamic = "force-static"
+
+export function generateStaticParams() {
+  return SPLASH_SIZES.map(({ w, h }) => ({ size: `${w}x${h}` }))
+}
+
+export async function GET(_: Request, { params }: { params: Promise<{ size: string }> }) {
+  const { size } = await params
+  const match = SPLASH_SIZES.find((s) => `${s.w}x${s.h}` === size)
+  if (!match) return new Response("Not found", { status: 404 })
+
+  return new ImageResponse(splashJsx(match.w, match.h), { width: match.w, height: match.h })
+}

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -1,29 +1,101 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 
 export default function ServiceWorkerRegistration() {
+  const [waiting, setWaiting] = useState<ServiceWorker | null>(null)
+
   useEffect(() => {
     if (!("serviceWorker" in navigator)) return
 
     // 初回インストール時は controllerchange でリロードしない（既存コントローラーがある時のみ更新リロード）
     const hadController = !!navigator.serviceWorker.controller
+    let registration: ServiceWorkerRegistration | undefined
+    let reloading = false
+
+    const trackInstalling = (installing: ServiceWorker | null) => {
+      if (!installing) return
+      installing.addEventListener("statechange", () => {
+        // 既に controller がある = 更新版（初回インストールではない）
+        if (installing.state === "installed" && navigator.serviceWorker.controller) {
+          setWaiting(installing)
+        }
+      })
+    }
+
+    const onControllerChange = () => {
+      if (!hadController || reloading) return
+      reloading = true
+      window.location.reload()
+    }
+
+    // iOS PWA はバックグラウンド復帰時に SW を自動チェックしないため強制更新
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return
+      registration?.update().catch(() => {})
+    }
+
+    navigator.serviceWorker.addEventListener("controllerchange", onControllerChange)
+    document.addEventListener("visibilitychange", onVisibilityChange)
 
     navigator.serviceWorker
       .register("/sw.js", { scope: "/", updateViaCache: "none" })
-      .then((registration) => {
-        const checkUpdate = () => registration.update().catch(() => {})
-        // iOS PWA はバックグラウンド復帰時に SW を自動チェックしないため強制更新
-        document.addEventListener("visibilitychange", () => {
-          if (document.visibilityState === "visible") checkUpdate()
-        })
+      .then((reg) => {
+        registration = reg
+        if (reg.waiting && navigator.serviceWorker.controller) setWaiting(reg.waiting)
+        trackInstalling(reg.installing)
+        reg.addEventListener("updatefound", () => trackInstalling(reg.installing))
       })
       .catch(() => {})
 
-    // 新しい SW が制御を引き継いだらページをリロード（初回インストール除く）
-    const onControllerChange = () => { if (hadController) window.location.reload() }
-    navigator.serviceWorker.addEventListener("controllerchange", onControllerChange)
-    return () => navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange)
+    return () => {
+      navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
+    }
   }, [])
-  return null
+
+  if (!waiting) return null
+
+  return (
+    <div
+      role="alert"
+      data-testid="sw-update-banner"
+      style={{
+        position: "fixed",
+        bottom: "16px",
+        left: "16px",
+        right: "16px",
+        zIndex: 9999,
+        background: "rgba(16, 0, 10, 0.95)",
+        border: "1px solid #dc143c",
+        boxShadow: "0 0 16px #dc143c, inset 0 0 16px rgba(220,20,60,0.1)",
+        color: "#dc143c",
+        padding: "12px 16px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "12px",
+        fontSize: "12px",
+        letterSpacing: "0.1em",
+      }}
+    >
+      <span>新しいバージョンが利用可能です</span>
+      <button
+        type="button"
+        onClick={() => waiting.postMessage({ type: "SKIP_WAITING" })}
+        style={{
+          background: "#dc143c",
+          color: "#10000a",
+          border: "none",
+          padding: "8px 16px",
+          fontSize: "12px",
+          fontWeight: "bold",
+          letterSpacing: "0.15em",
+          cursor: "pointer",
+        }}
+      >
+        更新
+      </button>
+    </div>
+  )
 }

--- a/src/constants/splash.ts
+++ b/src/constants/splash.ts
@@ -1,0 +1,30 @@
+// iOS PWA apple-touch-startup-image 対応サイズ
+// device-width / height は CSS ピクセル、w / h は実 PNG ピクセル（DPR 込み）
+export type SplashSize = {
+  w: number
+  h: number
+  cssW: number
+  cssH: number
+  dpr: number
+}
+
+export const SPLASH_SIZES: readonly SplashSize[] = [
+  { w: 1320, h: 2868, cssW: 440, cssH: 956, dpr: 3 }, // iPhone 16 Pro Max
+  { w: 1206, h: 2622, cssW: 402, cssH: 874, dpr: 3 }, // iPhone 16 Pro
+  { w: 1290, h: 2796, cssW: 430, cssH: 932, dpr: 3 }, // iPhone 15/14 Pro Max
+  { w: 1284, h: 2778, cssW: 428, cssH: 926, dpr: 3 }, // iPhone 14 Plus / 13/12 Pro Max
+  { w: 1179, h: 2556, cssW: 393, cssH: 852, dpr: 3 }, // iPhone 15/15 Pro / 14/14 Pro
+  { w: 1170, h: 2532, cssW: 390, cssH: 844, dpr: 3 }, // iPhone 13/13 Pro / 12/12 Pro
+  { w: 1242, h: 2688, cssW: 414, cssH: 896, dpr: 3 }, // iPhone 11 Pro Max / XS Max
+  { w: 1125, h: 2436, cssW: 375, cssH: 812, dpr: 3 }, // iPhone 11 Pro / XS / X
+  { w: 1080, h: 2340, cssW: 360, cssH: 780, dpr: 3 }, // iPhone 13 mini / 12 mini
+  { w: 828, h: 1792, cssW: 414, cssH: 896, dpr: 2 }, // iPhone 11 / XR
+  { w: 750, h: 1334, cssW: 375, cssH: 667, dpr: 2 }, // iPhone SE 2/3 / 8 / 7 / 6s
+] as const
+
+export function splashStartupImages() {
+  return SPLASH_SIZES.map(({ w, h, cssW, cssH, dpr }) => ({
+    url: `/splash/${w}x${h}`,
+    media: `(device-width: ${cssW}px) and (device-height: ${cssH}px) and (-webkit-device-pixel-ratio: ${dpr}) and (orientation: portrait)`,
+  }))
+}

--- a/src/lib/splash-jsx.tsx
+++ b/src/lib/splash-jsx.tsx
@@ -1,0 +1,21 @@
+import { cyberIconJsx } from "./cyber-icon-jsx"
+
+export function splashJsx(width: number, height: number) {
+  const iconSize = Math.round(Math.min(width, height) * 0.36)
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#10000a",
+      }}
+    >
+      <div style={{ width: iconSize, height: iconSize, display: "flex" }}>
+        {cyberIconJsx(iconSize)}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- iOS の PWA スプラッシュ用に主要 iPhone 11 サイズの動的 PNG ルート (`/splash/[w]x[h]`) を追加し、`layout.tsx` の `appleWebApp.startupImage` で各 device-width / dpr に紐付け
- Service Worker の `install` から `skipWaiting()` を撤廃して `waiting` で待機させ、クライアント側で更新通知バナーを出してユーザーが「更新」を押した時に `SKIP_WAITING` を postMessage する構成に変更
- 初回インストール時のリロード抑止は既存の `hadController` チェックで維持
- スプラッシュ／メタタグ／SW メッセージハンドラの Playwright テストを追加

## Test plan
- [x] `npm run test:unit` — 257 件パス
- [x] `npx playwright test` — 43 件パス（新規追加 4 件含む）
- [ ] iOS の実機 PWA でスプラッシュが各サイズで正しく出ること
- [ ] デプロイ後、別端末で開いた状態で再デプロイ → 更新バナーが出て「更新」で反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)