### PR TITLE
fix(notion): タスク取得を pagination 化し未着手/進行中の取りこぼしを解消

### DIFF
--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -86,24 +86,37 @@ function pageToTask(page: PageObjectResponse): Task {
 }
 
 async function fetchTasks(statuses: TaskStatus[]): Promise<Task[]> {
+  // ボード化で全ステータスを 1 クエリで取るようになったため、page_size 100
+  // (Notion API デフォルト) では完了/中止が大量にあると未着手・進行中が
+  // 切り落とされる。has_more が消えるまでカーソル送りして全件取得する。
   try {
-    const response = await notion.dataSources.query({
-      data_source_id: DATA_SOURCE_ID,
-      filter: {
-        or: statuses.map((s) => ({
-          property: NOTION_PROPS.STATUS,
-          status: { equals: s },
-        })),
-      },
-      sorts: [
-        { property: NOTION_PROPS.PRIORITY, direction: "ascending" },
-        { property: NOTION_PROPS.DUE,      direction: "ascending" },
-      ],
-    })
+    const all: PageObjectResponse[] = []
+    let cursor: string | undefined = undefined
 
-    return response.results
-      .filter((r): r is PageObjectResponse => r.object === "page" && "properties" in r)
-      .map(pageToTask)
+    do {
+      const response = await notion.dataSources.query({
+        data_source_id: DATA_SOURCE_ID,
+        filter: {
+          or: statuses.map((s) => ({
+            property: NOTION_PROPS.STATUS,
+            status: { equals: s },
+          })),
+        },
+        sorts: [
+          { property: NOTION_PROPS.PRIORITY, direction: "ascending" },
+          { property: NOTION_PROPS.DUE,      direction: "ascending" },
+        ],
+        page_size: 100,
+        ...(cursor ? { start_cursor: cursor } : {}),
+      })
+
+      for (const r of response.results) {
+        if (r.object === "page" && "properties" in r) all.push(r as PageObjectResponse)
+      }
+      cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
+    } while (cursor)
+
+    return all.map(pageToTask)
   } catch (e) {
     console.error("[getTasks] Notion error:", e)
     return []


### PR DESCRIPTION
## Summary

- ボード化で `getTasks` のデフォルトを全 6 ステータスに広げたが、`fetchTasks` が Notion API の `dataSources.query` を pagination せず page_size 100 のまま 1 回だけ叩いていたため、完了・中止が大量にある本番環境では未着手/進行中が取りこぼされていた。
- `has_more` が消えるまで `start_cursor` で送って全件回収するよう修正。

## 原因の解説

- 旧仕様（active filter）では `["未着手", "進行中"]` の 2 つだけクエリ → そもそも 100 件を超えにくかった。
- ボード化で `["未着手", "進行中", "確認中", "一時中断", "完了", "中止"]` の OR フィルタになり、レスポンスが priority 昇順 → due 昇順で並ぶ結果、優先度未設定が大量にあると先頭 100 件が「完了」「中止」で埋まり、末尾の「未着手」「進行中」が切り落とされる事象が起きた。
- `getTaskBlocks` / `getTaskComments` は既に同じ pagination 形式で実装されており、それと整合する形に。

## Test plan

- [x] `npm run test:unit` — 234 件パス（dev モックは pagination 非経由）
- [x] `npx playwright test` — 35 件パス
- [ ] 本番デプロイ後、ボードに未着手・進行中カラムが描画されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)