### PR TITLE
perf(notion): 通信ラウンドトリップを削減（本文保存 N+1 並列化 / updateTag 統一 / タグキャッシュ）

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { revalidatePath, revalidateTag } from "next/cache"
+import { updateTag } from "next/cache"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { auth } from "@/auth"
@@ -33,28 +33,24 @@ export async function updateTaskStatus(id: string, status: TaskStatus) {
     console.error("[updateTaskStatus] Notion error:", e)
     throw e
   }
-  revalidateTag("tasks", "default")
-  revalidatePath("/")
+  updateTag("tasks")
 }
 
 export async function createTaskAction(input: CreateTaskInput) {
   await requireAuth()
   await createTask(input)
-  revalidateTag("tasks", "default")
-  revalidatePath("/")
+  updateTag("tasks")
 }
 
 export async function updateTaskAction(id: string, input: UpdateTaskInput) {
   await requireAuth()
   await updateTask(id, input)
-  revalidateTag("tasks", "default")
-  revalidatePath("/")
+  updateTag("tasks")
 }
 
 export async function refreshTasksAction() {
   await requireAuth()
-  revalidateTag("tasks", "default")
-  revalidatePath("/")
+  updateTag("tasks")
 }
 
 export async function getTaskBlocksAction(id: string): Promise<string> {

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -140,8 +140,7 @@ export function getTasks(options?: {
   )()
 }
 
-export async function getTagOptions(): Promise<string[]> {
-  if (isDevMode()) return getMockTagOptions()
+async function fetchTagOptions(): Promise<string[]> {
   try {
     const ds = await notion.dataSources.retrieve({ data_source_id: DATA_SOURCE_ID })
     const tagProp = (ds as { properties: Record<string, unknown> }).properties?.[NOTION_PROPS.TAG] as
@@ -152,6 +151,15 @@ export async function getTagOptions(): Promise<string[]> {
     console.error("[getTagOptions] Notion error:", e)
     return []
   }
+}
+
+export function getTagOptions(): Promise<string[]> {
+  if (isDevMode()) return Promise.resolve(getMockTagOptions())
+  return unstable_cache(
+    fetchTagOptions,
+    ["tag-options"],
+    { tags: ["tasks"] }
+  )()
 }
 
 export async function getTask(id: string): Promise<Task | null> {
@@ -432,6 +440,7 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
     // Fetch existing blocks; delete only non-image blocks so user-attached
     // images survive a body edit (file-type Notion images use signed URLs
     // that can't be safely re-created).
+    const idsToDelete: string[] = []
     let cursor: string | undefined = undefined
     do {
       const response = await notion.blocks.children.list({
@@ -441,10 +450,18 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
       })
       for (const block of response.results) {
         if (isFullBlockObjectResponse(block) && (block as { type: string }).type === "image") continue
-        await notion.blocks.delete({ block_id: block.id })
+        idsToDelete.push(block.id)
       }
       cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
     } while (cursor)
+
+    // Notion API のレート上限は 3 req/s 想定。3 件ずつバッチで並列削除して
+    // 直列 await による N+1 ラウンドトリップを潰す。
+    const BATCH = 3
+    for (let i = 0; i < idsToDelete.length; i += BATCH) {
+      const batch = idsToDelete.slice(i, i + BATCH)
+      await Promise.all(batch.map((bid) => notion.blocks.delete({ block_id: bid })))
+    }
 
     // Strip image markdown lines: existing image blocks were preserved above,
     // so re-creating them would duplicate (and create dead links for


### PR DESCRIPTION
## Summary

本番（Cloudflare Workers / Pages）で「本文保存」「ステータス変更」「タスク詳細を開く」が遅かった件の構造的な原因の上位 3 点を修正。原因特定は別途行ったうえで、最も低リスクで効果が大きい 3 箇所のみを本 PR で対処。

### H1: 本文保存のブロック削除を 3 並列バッチ化（最大インパクト）
`src/lib/notion.ts:updateTaskBlocks`
- `notion.blocks.delete` を 1 件ずつ `await` していた N+1 直列を、3 件ずつ `Promise.all` バッチに変更
- Notion API レート制限 3 req/s に整合
- 100 ブロックの本文保存で 100 ラウンドトリップ→ ~33 ラウンドトリップに削減

### H2: revalidate を `updateTag("tasks")` に統一（中インパクト）
`src/app/actions.ts`
- `revalidateTag("tasks", "default") + revalidatePath("/")` の二段構成を `updateTag("tasks")` 一本に
- Next.js 16 の `updateTag` は Server Action 専用で read-your-own-writes セマンティクス、profile=undefined のため `pathWasRevalidated=ActionDidRevalidate` がセットされ router refresh + tasks タグ即時無効化が同時に走る
- 副次効果: `revalidateTag(tag, "max")` だと cacheLife.expire=1y で path revalidation がスキップされ、タスク作成後にボードへ反映されないことが Playwright で再現

### H5: `getTagOptions` を `unstable_cache` でラップ（小〜中インパクト）
`src/lib/notion.ts:getTagOptions`
- 元実装は無キャッシュで毎リクエスト `notion.dataSources.retrieve` を叩いていた
- `tasks` タグでラップしたので、タスク変更時に一緒に無効化される

## 計測前なのでスコープから外した点

- H3: `TaskDetail` の blocks/comments を 1 本の Server Action に統合 → 効果は数百 ms、変更範囲が広いので別 PR
- 本番で `wrangler tail` を流しての計測は別途実施し、各仮説のインパクトを後追い

## Test plan

- [x] `npm run test:unit`: 234 / 234 passed
- [x] `npx playwright test`: 35 / 35 passed（クリーン状態 = `docker compose down` 後に実行）
- [ ] 本番デプロイ後、3 操作（本文保存・ステータス変更・タスク詳細を開く）の体感確認
- [ ] 必要に応じて `wrangler tail` で実測値を取り、効果を裏付け