### PR TITLE
perf(notion): 本文更新時のブロック削除を 10 並列化

### DIFF
--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -455,9 +455,9 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
       cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
     } while (cursor)
 
-    // Notion API のレート上限は 3 req/s 想定。3 件ずつバッチで並列削除して
-    // 直列 await による N+1 ラウンドトリップを潰す。
-    const BATCH = 3
+    // Notion API は 3 req/s 平均だがバースト許容。10 並列まで広げて
+    // 削除のラウンドトリップ数を抑える。
+    const BATCH = 10
     for (let i = 0; i < idsToDelete.length; i += BATCH) {
       const batch = idsToDelete.slice(i, i + BATCH)
       await Promise.all(batch.map((bid) => notion.blocks.delete({ block_id: bid })))


### PR DESCRIPTION
## Summary

- `updateTaskBlocks` のブロック削除バッチサイズを `3 → 10` に拡張
- Notion API は 3 req/s 平均だがバースト許容なので、削除のラウンドトリップ数を約 1/3 に短縮
- 30 ブロック削除なら 10 バッチ → 3 バッチに減り、本文更新の体感が大きく改善するはず

## Test plan

- [x] `npm run test:unit` (234 passed)
- [x] `npx playwright test` (35 passed)
- [ ] 本文を編集して保存し、デバッグパネルで所要時間が短縮されていることを確認
- [ ] 大量ブロックがあるタスクでレート上限エラー (429) が出ないことを確認