### PR TITLE
perf(notion): 本文更新を LCS 差分ベースに変更

### DIFF
--- a/src/lib/__tests__/notion.test.ts
+++ b/src/lib/__tests__/notion.test.ts
@@ -597,4 +597,64 @@ describe("updateTaskBlocks", () => {
     const types = appendCall.children.map((b: { type: string }) => b.type)
     expect(types).toEqual(["heading_1", "paragraph"])
   })
+
+  it("差分更新: 内容が完全一致なら delete も append も呼ばれない", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文1" }] } },
+        { id: "p2", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文2" }] } },
+        { id: "p3", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文3" }] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "本文1\n本文2\n本文3")
+
+    expect(mockBlocks.delete).not.toHaveBeenCalled()
+    expect(mockBlocks.children.append).not.toHaveBeenCalled()
+  })
+
+  it("差分更新: 中間の1行を変更したら、その1ブロックのみ delete + insert", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文1" }] } },
+        { id: "p2", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文2" }] } },
+        { id: "p3", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文3" }] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "本文1\n本文2変更\n本文3")
+
+    const deletedIds = mockBlocks.delete.mock.calls.map((c: [{ block_id: string }]) => c[0].block_id)
+    expect(deletedIds).toEqual(["p2"])
+
+    expect(mockBlocks.children.append).toHaveBeenCalledTimes(1)
+    const appendCall = mockBlocks.children.append.mock.calls[0][0]
+    expect(appendCall.after).toBe("p1")
+    expect(appendCall.children).toHaveLength(1)
+    expect(appendCall.children[0].paragraph.rich_text[0].text.content).toBe("本文2変更")
+  })
+
+  it("差分更新: 末尾に1行追加したら delete なし、append は after なし1コール", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文1" }] } },
+        { id: "p2", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文2" }] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "本文1\n本文2\n本文3")
+
+    expect(mockBlocks.delete).not.toHaveBeenCalled()
+    expect(mockBlocks.children.append).toHaveBeenCalledTimes(1)
+    const appendCall = mockBlocks.children.append.mock.calls[0][0]
+    expect(appendCall.after).toBe("p2")
+    expect(appendCall.children).toHaveLength(1)
+    expect(appendCall.children[0].paragraph.rich_text[0].text.content).toBe("本文3")
+  })
 })

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -431,16 +431,87 @@ export async function createTaskComment(id: string, text: string, author = "Unkn
 
 const IMAGE_MARKDOWN_LINE = /^!\[[^\]]*\]\(.+\)$/
 
+// 旧ブロック (API レスポンス, rich_text[].plain_text) と新ブロック (作成ペイロード,
+// rich_text[].text.content) で同じキーを生成するため、それぞれ専用のヘルパを使う。
+function oldBlockDiffKey(block: BlockObjectResponse): string {
+  const b = block as Record<string, unknown>
+  const type = b.type as string
+  if (type === "divider") return "divider"
+  if (type === "code") {
+    const cd = b.code as { rich_text: Array<{ plain_text: string }>; language?: string }
+    return `code|${cd.language ?? ""}|${extractPlainText(cd.rich_text)}`
+  }
+  if (type === "to_do") {
+    const td = b.to_do as { rich_text: Array<{ plain_text: string }>; checked: boolean }
+    return `to_do|${td.checked ? 1 : 0}|${extractPlainText(td.rich_text)}`
+  }
+  const data = b[type] as { rich_text?: Array<{ plain_text: string }> } | undefined
+  const text = data?.rich_text ? extractPlainText(data.rich_text) : ""
+  return `${type}|${text}`
+}
+
+function newBlockDiffKey(block: object): string {
+  const b = block as Record<string, unknown>
+  const type = b.type as string
+  if (type === "divider") return "divider"
+  const newRichText = (rt: Array<{ text: { content: string } }>) =>
+    rt.map((r) => r.text.content).join("")
+  if (type === "code") {
+    const cd = b.code as { rich_text: Array<{ text: { content: string } }>; language?: string }
+    return `code|${cd.language ?? ""}|${newRichText(cd.rich_text)}`
+  }
+  if (type === "to_do") {
+    const td = b.to_do as { rich_text: Array<{ text: { content: string } }>; checked: boolean }
+    return `to_do|${td.checked ? 1 : 0}|${newRichText(td.rich_text)}`
+  }
+  const data = b[type] as { rich_text?: Array<{ text: { content: string } }> } | undefined
+  const text = data?.rich_text ? newRichText(data.rich_text) : ""
+  return `${type}|${text}`
+}
+
+type DiffOp =
+  | { kind: "keep"; oldIdx: number; newIdx: number }
+  | { kind: "delete"; oldIdx: number }
+  | { kind: "insert"; newIdx: number }
+
+function lcsDiff(oldKeys: string[], newKeys: string[]): DiffOp[] {
+  const m = oldKeys.length
+  const n = newKeys.length
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = oldKeys[i - 1] === newKeys[j - 1]
+        ? dp[i - 1][j - 1] + 1
+        : Math.max(dp[i - 1][j], dp[i][j - 1])
+    }
+  }
+  const ops: DiffOp[] = []
+  let i = m
+  let j = n
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldKeys[i - 1] === newKeys[j - 1]) {
+      ops.push({ kind: "keep", oldIdx: i - 1, newIdx: j - 1 })
+      i--
+      j--
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.push({ kind: "insert", newIdx: j - 1 })
+      j--
+    } else {
+      ops.push({ kind: "delete", oldIdx: i - 1 })
+      i--
+    }
+  }
+  return ops.reverse()
+}
+
 export async function updateTaskBlocks(id: string, markdown: string): Promise<void> {
   if (isDevMode()) {
     updateMockTaskBlocks(id, markdown)
     return
   }
   try {
-    // Fetch existing blocks; delete only non-image blocks so user-attached
-    // images survive a body edit (file-type Notion images use signed URLs
-    // that can't be safely re-created).
-    const idsToDelete: string[] = []
+    // 1. 既存ブロックを取得
+    const oldBlocks: BlockObjectResponse[] = []
     let cursor: string | undefined = undefined
     do {
       const response = await notion.blocks.children.list({
@@ -449,34 +520,72 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
         ...(cursor ? { start_cursor: cursor } : {}),
       })
       for (const block of response.results) {
-        if (isFullBlockObjectResponse(block) && (block as { type: string }).type === "image") continue
-        idsToDelete.push(block.id)
+        if (isFullBlockObjectResponse(block)) oldBlocks.push(block)
       }
       cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
     } while (cursor)
 
-    // Notion API は 3 req/s 平均だがバースト許容。10 並列まで広げて
-    // 削除のラウンドトリップ数を抑える。
-    const BATCH = 10
-    for (let i = 0; i < idsToDelete.length; i += BATCH) {
-      const batch = idsToDelete.slice(i, i + BATCH)
-      await Promise.all(batch.map((bid) => notion.blocks.delete({ block_id: bid })))
-    }
+    // 2. 画像はそのまま保持。それ以外を diff 対象とする。
+    //    file-type の画像は署名付き URL なので作り直せない。
+    const oldTextBlocks = oldBlocks.filter((b) => (b as { type: string }).type !== "image")
 
-    // Strip image markdown lines: existing image blocks were preserved above,
-    // so re-creating them would duplicate (and create dead links for
-    // Notion-hosted file URLs that have since expired).
+    // 3. 入力 markdown から画像行を除外（既存画像との二重防止）
     const textOnly = markdown
       .split("\n")
       .filter((line) => !IMAGE_MARKDOWN_LINE.test(line))
       .join("\n")
-
     const newBlocks = markdownToNotionBlocks(textOnly)
-    if (newBlocks.length > 0) {
-      await notion.blocks.children.append({
+
+    // 4. ブロック単位の安定キーで LCS 差分。同じ内容のブロックは何もしない。
+    const oldKeys = oldTextBlocks.map(oldBlockDiffKey)
+    const newKeys = newBlocks.map(newBlockDiffKey)
+    const ops = lcsDiff(oldKeys, newKeys)
+
+    // 5. delete 対象を集める
+    const idsToDelete: string[] = []
+    for (const op of ops) {
+      if (op.kind === "delete") idsToDelete.push(oldTextBlocks[op.oldIdx].id)
+    }
+
+    // 6. insert は連続するものを1コールにまとめ、直前の keep ブロック ID を after に指定。
+    //    keep が無いまま insert する場合は after なし（= ページ末尾に追加）。
+    type InsertGroup = { after: string | null; payloads: object[] }
+    const insertGroups: InsertGroup[] = []
+    let currentGroup: InsertGroup | null = null
+    let lastKeptId: string | null = null
+    for (const op of ops) {
+      if (op.kind === "keep") {
+        lastKeptId = oldTextBlocks[op.oldIdx].id
+        currentGroup = null
+      } else if (op.kind === "delete") {
+        currentGroup = null
+      } else {
+        if (currentGroup === null) {
+          currentGroup = { after: lastKeptId, payloads: [] }
+          insertGroups.push(currentGroup)
+        }
+        currentGroup.payloads.push(newBlocks[op.newIdx])
+      }
+    }
+
+    // 7. delete と insert は別ブロックを触るので並走可。並列度 10 で実行。
+    type Task = () => Promise<unknown>
+    const tasks: Task[] = []
+    for (const bid of idsToDelete) {
+      tasks.push(() => notion.blocks.delete({ block_id: bid }))
+    }
+    for (const g of insertGroups) {
+      tasks.push(() => notion.blocks.children.append({
         block_id: id,
-        children: newBlocks as Parameters<typeof notion.blocks.children.append>[0]["children"],
-      })
+        children: g.payloads as Parameters<typeof notion.blocks.children.append>[0]["children"],
+        ...(g.after ? { after: g.after } : {}),
+      }))
+    }
+
+    const CONCURRENCY = 10
+    for (let i = 0; i < tasks.length; i += CONCURRENCY) {
+      const batch = tasks.slice(i, i + CONCURRENCY)
+      await Promise.all(batch.map((t) => t()))
     }
   } catch (e) {
     console.error("[updateTaskBlocks] Notion error:", e)


### PR DESCRIPTION
## Summary

これまでは本文保存ごとに「画像以外を全削除 → 全 append」しており、
ブロック数 N に対して直列に O(N) 個の API RT が発生して
中身がほぼ変わっていなくても 10s 超かかっていた。

ブロック単位の安定キー (type + 内容) で旧/新を LCS 差分し、
- 一致 = 何もしない
- 不要分だけ \`blocks.delete\`
- 追加分の連続ブロックは1コールにまとめて \`blocks.children.append({ after })\`

で最小限に抑える。delete と insert は別ブロックを触るので並列度 10 で並走。

## 効果（理論値）

| シナリオ (例: 既存30ブロック) | 旧 | 新 |
|---|---|---|
| 未編集で保存 | 30 deletes + 1 append | **0 calls** |
| 末尾に1行追加 | 30 deletes + 1 append (31 children) | 1 append |
| 中間1行を編集 | 30 deletes + 1 append (30 children) | 1 delete + 1 append (1 child) |
| 全行差し替え | 30 deletes + 1 append | 30 deletes + 1 append（変わらず） |

## Test plan

- [x] \`npm run test:unit\` 237 passed (+3 件: 同一/中間1行編集/末尾追加)
- [x] \`npx playwright test\` 35 passed
- [ ] 実 Notion で本文を1行だけ編集して保存し、デバッグパネル所要時間が大幅短縮されることを確認
- [ ] 画像のあるタスクで本文を編集しても画像が消えないことを確認

## Notes

- 画像は diff 対象外で常に保持（既存挙動と同じ）
- LCS は O(M*N) DP。本文 100 行までなら問題なし
- code ブロックは language が一致しないと差分でマッチしないため delete+insert 扱いになる（実用上は問題ないはず）