### PR TITLE
perf(notion): 同位置・同 type の置換を blocks.update に集約

### DIFF
--- a/src/lib/__tests__/notion.test.ts
+++ b/src/lib/__tests__/notion.test.ts
@@ -14,6 +14,7 @@ const { mockPages, mockDataSources, mockBlocks } = vi.hoisted(() => ({
   mockBlocks: {
     children: { list: vi.fn(), append: vi.fn() },
     delete: vi.fn(),
+    update: vi.fn(),
   },
 }))
 
@@ -541,11 +542,13 @@ describe("updateTaskBlocks", () => {
     mockBlocks.children.list.mockReset()
     mockBlocks.children.append.mockReset()
     mockBlocks.delete.mockReset()
+    mockBlocks.update.mockReset()
     mockBlocks.children.append.mockResolvedValue({})
     mockBlocks.delete.mockResolvedValue({})
+    mockBlocks.update.mockResolvedValue({})
   })
 
-  it("image ブロックは delete されず、それ以外は delete される", async () => {
+  it("image ブロックは delete されず、それ以外は最小限の操作で更新される", async () => {
     mockBlocks.children.list.mockResolvedValue({
       results: [
         { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "古い本文" }] } },
@@ -559,8 +562,13 @@ describe("updateTaskBlocks", () => {
     await updateTaskBlocks("page-1", "新しい本文")
 
     const deletedIds = mockBlocks.delete.mock.calls.map((c: [{ block_id: string }]) => c[0].block_id)
-    expect(deletedIds).toEqual(["p1", "p2"])
+    // 同 type (paragraph→paragraph) なので p1 は update に置換、p2 は不要なので delete
+    expect(deletedIds).toEqual(["p2"])
     expect(deletedIds).not.toContain("img1")
+    expect(mockBlocks.update).toHaveBeenCalledTimes(1)
+    const updateCall = mockBlocks.update.mock.calls[0][0]
+    expect(updateCall.block_id).toBe("p1")
+    expect(updateCall.paragraph.rich_text[0].text.content).toBe("新しい本文")
   })
 
   it("markdown 中の画像行は append されない（既存画像と二重にならない）", async () => {
@@ -615,7 +623,7 @@ describe("updateTaskBlocks", () => {
     expect(mockBlocks.children.append).not.toHaveBeenCalled()
   })
 
-  it("差分更新: 中間の1行を変更したら、その1ブロックのみ delete + insert", async () => {
+  it("差分更新: 中間の1行を同 type で書き換えたら blocks.update 1コールのみ", async () => {
     mockBlocks.children.list.mockResolvedValue({
       results: [
         { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "本文1" }] } },
@@ -628,14 +636,31 @@ describe("updateTaskBlocks", () => {
 
     await updateTaskBlocks("page-1", "本文1\n本文2変更\n本文3")
 
-    const deletedIds = mockBlocks.delete.mock.calls.map((c: [{ block_id: string }]) => c[0].block_id)
-    expect(deletedIds).toEqual(["p2"])
+    expect(mockBlocks.delete).not.toHaveBeenCalled()
+    expect(mockBlocks.children.append).not.toHaveBeenCalled()
+    expect(mockBlocks.update).toHaveBeenCalledTimes(1)
+    const updateCall = mockBlocks.update.mock.calls[0][0]
+    expect(updateCall.block_id).toBe("p2")
+    expect(updateCall.paragraph.rich_text[0].text.content).toBe("本文2変更")
+  })
 
+  it("差分更新: 同位置だが type が異なる置換は delete + insert になる", async () => {
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "ただの段落" }] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "# ただの段落")
+
+    expect(mockBlocks.update).not.toHaveBeenCalled()
+    const deletedIds = mockBlocks.delete.mock.calls.map((c: [{ block_id: string }]) => c[0].block_id)
+    expect(deletedIds).toEqual(["p1"])
     expect(mockBlocks.children.append).toHaveBeenCalledTimes(1)
     const appendCall = mockBlocks.children.append.mock.calls[0][0]
-    expect(appendCall.after).toBe("p1")
-    expect(appendCall.children).toHaveLength(1)
-    expect(appendCall.children[0].paragraph.rich_text[0].text.content).toBe("本文2変更")
+    expect(appendCall.children[0].type).toBe("heading_1")
   })
 
   it("差分更新: 末尾に1行追加したら delete なし、append は after なし1コール", async () => {

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -471,6 +471,7 @@ function newBlockDiffKey(block: object): string {
 
 type DiffOp =
   | { kind: "keep"; oldIdx: number; newIdx: number }
+  | { kind: "update"; oldIdx: number; newIdx: number }
   | { kind: "delete"; oldIdx: number }
   | { kind: "insert"; newIdx: number }
 
@@ -502,6 +503,65 @@ function lcsDiff(oldKeys: string[], newKeys: string[]): DiffOp[] {
     }
   }
   return ops.reverse()
+}
+
+// 同じ region (= keep に挟まれた delete/insert の連続) 内で、
+// 順序が同じ位置にある delete[k] / insert[k] を、type が一致するときに
+// blocks.update へ置き換える。ブロック ID と紐づくコメント/メンションを保つ
+// ためで、API コール数も 1 (delete) + 1 (insert) → 1 (update) に減る。
+// 順序ペアリング (d[k] ↔ i[k]) を厳守することで、ブロック並びの取り違えを防ぐ。
+function pairUpdatesInPlace(
+  ops: DiffOp[],
+  oldTextBlocks: BlockObjectResponse[],
+  newBlocks: object[]
+): DiffOp[] {
+  const result: DiffOp[] = []
+  let i = 0
+  while (i < ops.length) {
+    if (ops[i].kind === "keep") {
+      result.push(ops[i])
+      i++
+      continue
+    }
+    const regionStart = i
+    while (i < ops.length && ops[i].kind !== "keep") i++
+    const region = ops.slice(regionStart, i)
+
+    const deletes: { regionIdx: number; oldIdx: number }[] = []
+    const inserts: { regionIdx: number; newIdx: number }[] = []
+    region.forEach((o, idx) => {
+      if (o.kind === "delete") deletes.push({ regionIdx: idx, oldIdx: o.oldIdx })
+      else if (o.kind === "insert") inserts.push({ regionIdx: idx, newIdx: o.newIdx })
+    })
+
+    const pairedDelete = new Set<number>()
+    const pairedInsert = new Set<number>()
+    const updates = new Map<number, { oldIdx: number; newIdx: number }>()
+    const minLen = Math.min(deletes.length, inserts.length)
+    for (let k = 0; k < minLen; k++) {
+      const oldType = (oldTextBlocks[deletes[k].oldIdx] as { type: string }).type
+      const newType = (newBlocks[inserts[k].newIdx] as { type: string }).type
+      if (oldType === newType) {
+        pairedDelete.add(deletes[k].regionIdx)
+        pairedInsert.add(inserts[k].regionIdx)
+        updates.set(deletes[k].regionIdx, {
+          oldIdx: deletes[k].oldIdx,
+          newIdx: inserts[k].newIdx,
+        })
+      }
+    }
+
+    region.forEach((o, idx) => {
+      if (pairedInsert.has(idx)) return
+      if (pairedDelete.has(idx)) {
+        const u = updates.get(idx)!
+        result.push({ kind: "update", oldIdx: u.oldIdx, newIdx: u.newIdx })
+      } else {
+        result.push(o)
+      }
+    })
+  }
+  return result
 }
 
 export async function updateTaskBlocks(id: string, markdown: string): Promise<void> {
@@ -539,7 +599,10 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
     // 4. ブロック単位の安定キーで LCS 差分。同じ内容のブロックは何もしない。
     const oldKeys = oldTextBlocks.map(oldBlockDiffKey)
     const newKeys = newBlocks.map(newBlockDiffKey)
-    const ops = lcsDiff(oldKeys, newKeys)
+    const rawOps = lcsDiff(oldKeys, newKeys)
+
+    // 4-2. 同位置・同 type の delete+insert を blocks.update に置換
+    const ops = pairUpdatesInPlace(rawOps, oldTextBlocks, newBlocks)
 
     // 5. delete 対象を集める
     const idsToDelete: string[] = []
@@ -547,32 +610,44 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
       if (op.kind === "delete") idsToDelete.push(oldTextBlocks[op.oldIdx].id)
     }
 
-    // 6. insert は連続するものを1コールにまとめ、直前の keep ブロック ID を after に指定。
-    //    keep が無いまま insert する場合は after なし（= ページ末尾に追加）。
+    // 6. insert は連続するものを1コールにまとめ、直前の keep/update ブロック ID を after に指定。
+    //    update は元のブロック ID を保つので、anchor として keep と同等に扱える。
+    //    keep/update が無いまま insert する場合は after なし（= ページ末尾に追加）。
     type InsertGroup = { after: string | null; payloads: object[] }
     const insertGroups: InsertGroup[] = []
     let currentGroup: InsertGroup | null = null
-    let lastKeptId: string | null = null
+    let lastAnchorId: string | null = null
     for (const op of ops) {
-      if (op.kind === "keep") {
-        lastKeptId = oldTextBlocks[op.oldIdx].id
+      if (op.kind === "keep" || op.kind === "update") {
+        lastAnchorId = oldTextBlocks[op.oldIdx].id
         currentGroup = null
       } else if (op.kind === "delete") {
         currentGroup = null
       } else {
         if (currentGroup === null) {
-          currentGroup = { after: lastKeptId, payloads: [] }
+          currentGroup = { after: lastAnchorId, payloads: [] }
           insertGroups.push(currentGroup)
         }
         currentGroup.payloads.push(newBlocks[op.newIdx])
       }
     }
 
-    // 7. delete と insert は別ブロックを触るので並走可。並列度 10 で実行。
+    // 7. delete / update / insert は別ブロックを触るので並走可。並列度 10 で実行。
     type Task = () => Promise<unknown>
     const tasks: Task[] = []
     for (const bid of idsToDelete) {
       tasks.push(() => notion.blocks.delete({ block_id: bid }))
+    }
+    for (const op of ops) {
+      if (op.kind !== "update") continue
+      const oldBlock = oldTextBlocks[op.oldIdx]
+      const newBlock = newBlocks[op.newIdx] as Record<string, unknown>
+      const type = newBlock.type as string
+      const data = newBlock[type]
+      tasks.push(() => notion.blocks.update({
+        block_id: oldBlock.id,
+        [type]: data,
+      } as Parameters<typeof notion.blocks.update>[0]))
     }
     for (const g of insertGroups) {
       tasks.push(() => notion.blocks.children.append({


### PR DESCRIPTION
## Summary

LCS 差分後の region (keep に挟まれた delete/insert の連続) で、
順序ペアリング (d[k] ↔ i[k]) で type が一致するペアを \`blocks.update\` に置換する。

- **API コール数削減**: 同位置の置換が 1 delete + 1 insert → 1 update に
- **ブロック ID 保持**: コメント/メンション/インライン参照が切れない
- **並び取り違え防止**: コンテンツ類似度ではなく位置 k で厳密にペアリング

## 効果

| 編集パターン | LCS 差分のみ | + update 最適化 |
|---|---|---|
| 同 type 1 段落書き換え | 1 delete + 1 append | **1 update** |
| 同 type 連続 N 段落書き換え | N deletes + 1 append | **N updates** |
| type 変更 (paragraph → heading) | 1 delete + 1 append | 同左（変わらず） |
| 末尾追加・削除のみ | 変わらず | 変わらず |

## Test plan

- [x] \`npm run test:unit\` 238 passed
  - 同 type 中間1行書き換え → update 1コール、delete/append 0
  - type 不一致 (paragraph → heading_1) → 旧来の delete + insert
  - 画像保持テストも update 経路で通る
- [x] \`npx playwright test\` 35 passed
- [ ] 本番で本文を1行だけ編集 → 体感が更に短縮されることを確認
- [ ] 編集後もブロックに付いていた Notion コメントが残ることを確認