### PR TITLE
feat: バージョン表示 JST 化 + main push 毎の自動 bump

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,13 +7,26 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
       - run: npm ci
+
+      # main への push 1 回ごとに patch を +1 (10 で上位繰り上げ)。
+      # ビルドより前に bump して、デプロイ成果物に新バージョンを反映する。
+      - name: Bump version
+        id: bump
+        run: |
+          NEXT=$(node scripts/bump-version.mjs)
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+
       - run: npm run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -22,3 +35,15 @@ jobs:
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           APP_USERNAME: ${{ secrets.APP_USERNAME }}
           APP_PASSWORD: ${{ secrets.APP_PASSWORD }}
+
+      # デプロイ成功後に bump を main へ push 戻す。
+      # GITHUB_TOKEN による push は他 workflow を発火しないので無限ループしない。
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to v${{ steps.bump.outputs.version }}"
+          # 並行 PR マージで先に進んでいた場合に備えて rebase してから push
+          git pull --rebase origin main
+          git push

--- a/scripts/bump-version-core.mjs
+++ b/scripts/bump-version-core.mjs
@@ -1,0 +1,14 @@
+// 桁が 10 に達したら上位へ繰り上げる base-10 カウンタ:
+//   0.0.0 → ... → 0.0.9 → 0.1.0 → ... → 0.9.9 → 1.0.0
+// 標準 semver と異なり patch / minor は単桁に丸める。
+export function bumpVersion(version) {
+  const parts = version.split(".").map((n) => Number(n))
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+    throw new Error(`unexpected version format: ${version}`)
+  }
+  let [maj, min, pat] = parts
+  pat += 1
+  if (pat >= 10) { pat = 0; min += 1 }
+  if (min >= 10) { min = 0; maj += 1 }
+  return `${maj}.${min}.${pat}`
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// PR1つ (= main への push 1回) ごとに patch を +1。
+// 桁が 10 に達したら上位へ繰り上げ:
+//   0.0.0 → ... → 0.0.9 → 0.1.0 → ... → 0.9.9 → 1.0.0
+//
+// package.json と package-lock.json (top-level + packages[""]) を更新する。
+
+import { readFileSync, writeFileSync } from "node:fs"
+import { bumpVersion } from "./bump-version-core.mjs"
+
+const PKG = "package.json"
+const LOCK = "package-lock.json"
+
+function rewriteJson(path, mutate) {
+  const raw = readFileSync(path, "utf-8")
+  const data = JSON.parse(raw)
+  mutate(data)
+  const trailing = raw.endsWith("\n") ? "\n" : ""
+  writeFileSync(path, JSON.stringify(data, null, 2) + trailing)
+}
+
+const pkg = JSON.parse(readFileSync(PKG, "utf-8"))
+const next = bumpVersion(pkg.version)
+
+rewriteJson(PKG, (d) => { d.version = next })
+rewriteJson(LOCK, (d) => {
+  d.version = next
+  if (d.packages && d.packages[""]) d.packages[""].version = next
+})
+
+console.log(next)

--- a/src/components/VersionTag.tsx
+++ b/src/components/VersionTag.tsx
@@ -1,15 +1,20 @@
 // 左下に固定表示するビルド情報。デプロイ確認用に
-// `v0.1.0 · a1b2c3d · 05/09 16:45` 形式で出す。
+// `v0.1.0 · a1b2c3d · 05/09 16:45 JST` 形式で出す。
 // dev 環境では先頭に `[DEV]` を付ける。
+//
+// 表示は常に JST (Asia/Tokyo) に固定する。Cloudflare Workers (UTC) で SSR
+// された結果とブラウザ側 (任意 TZ) のクライアント描画を一致させて
+// hydration mismatch を防ぐ目的も兼ねる。
 function formatBuildTime(iso: string | undefined): string {
   if (!iso) return ""
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return ""
-  const mm = String(d.getMonth() + 1).padStart(2, "0")
-  const dd = String(d.getDate()).padStart(2, "0")
-  const hh = String(d.getHours()).padStart(2, "0")
-  const mi = String(d.getMinutes()).padStart(2, "0")
-  return `${mm}/${dd} ${hh}:${mi}`
+  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000)
+  const mm = String(jst.getUTCMonth() + 1).padStart(2, "0")
+  const dd = String(jst.getUTCDate()).padStart(2, "0")
+  const hh = String(jst.getUTCHours()).padStart(2, "0")
+  const mi = String(jst.getUTCMinutes()).padStart(2, "0")
+  return `${mm}/${dd} ${hh}:${mi} JST`
 }
 
 export function VersionTag() {

--- a/src/lib/__tests__/bump-version.test.ts
+++ b/src/lib/__tests__/bump-version.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest"
+// @ts-expect-error mjs スクリプトを直接 import
+import { bumpVersion } from "../../../scripts/bump-version-core.mjs"
+
+describe("bumpVersion", () => {
+  it("patch を +1 する", () => {
+    expect(bumpVersion("0.0.0")).toBe("0.0.1")
+    expect(bumpVersion("0.1.0")).toBe("0.1.1")
+    expect(bumpVersion("1.2.3")).toBe("1.2.4")
+  })
+
+  it("patch が 9 の次は minor に繰り上げ", () => {
+    expect(bumpVersion("0.0.9")).toBe("0.1.0")
+    expect(bumpVersion("1.2.9")).toBe("1.3.0")
+  })
+
+  it("minor が 9 で patch も繰り上げなら major に繰り上げ", () => {
+    expect(bumpVersion("0.9.9")).toBe("1.0.0")
+    expect(bumpVersion("1.9.9")).toBe("2.0.0")
+  })
+
+  it("不正なバージョン文字列は例外", () => {
+    expect(() => bumpVersion("abc")).toThrow()
+    expect(() => bumpVersion("1.2")).toThrow()
+    expect(() => bumpVersion("1.x.3")).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

### 1. バージョン表示の JST 化
- \`VersionTag\` のビルド時刻を Asia/Tokyo に固定
- \`getTime() + 9h\` → \`getUTC*\` で TZ 非依存に算出。Cloudflare Workers (UTC) の SSR とブラウザの CSR で同じ文字列を吐くので hydration mismatch も同時解消
- 表示例: \`v0.1.0 · cb47220 · 05/09 23:30 JST\`

### 2. main への push 1回ごとに自動 bump
- \`scripts/bump-version.mjs\`: \`package.json\` / \`package-lock.json\` の version を +0.0.1
- 桁が 10 に達したら上位繰り上げ: 0.0.0 → ... → 0.0.9 → 0.1.0 → ... → 0.9.9 → 1.0.0
- ロジックは \`bump-version-core.mjs\` に切り出して vitest で検証
- \`deploy.yml\`: 「bump → build/deploy → commit & push 戻し」の順に変更
  - GITHUB_TOKEN 経由の push は他 workflow を発火しないため無限ループしない
  - 並行マージへの保険として push 直前に \`git pull --rebase\`

## Test plan

- [x] \`npm run test:unit\` 242 passed (+4 件: bump 関数の各分岐)
- [x] \`npx playwright test\` 35 passed
- [x] スクリプト動作確認: 0.1.0 → 0.1.1 と書き出される (実行後はローカルで revert 済)
- [ ] マージ後、CI が bump コミット (\`chore: bump version to v0.1.1\`) を main に push し、デプロイ後に v0.1.1 が表示されることを確認
- [ ] バージョン表示の時刻部分が JST であることを確認