### PR TITLE
fix(notion): 本文の更新内容が末尾に追記されてしまうバグを修正

### DIFF
--- a/src/lib/__tests__/notion.test.ts
+++ b/src/lib/__tests__/notion.test.ts
@@ -663,6 +663,91 @@ describe("updateTaskBlocks", () => {
     expect(appendCall.children[0].type).toBe("heading_1")
   })
 
+  it("差分更新: 先頭に1行追加したら、新しい行が body の先頭に正しく入る (旧 BUG: 末尾に追記)", async () => {
+    // Old: [p"Y"], New: "X\nY"
+    // 旧実装は head insert にアンカーが無く after 無しで append → ページ末尾になり
+    // 結果が "Y\nX" になってしまっていた。
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "Y" }] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "X\nY")
+
+    // 期待: 既存 p1 を "X" に書き換え + p1 の後ろに "Y" を append (= 全体が X→Y)。
+    // または: 何らかの形で head insert が p1 より前/と入れ替わる結果になっていれば良い。
+    // 重要なのは「末尾に 'X' が単に追加されただけ (Y\nX)」にならないこと。
+    expect(mockBlocks.update).toHaveBeenCalledTimes(1)
+    const updateCall = mockBlocks.update.mock.calls[0][0]
+    expect(updateCall.block_id).toBe("p1")
+    expect(updateCall.paragraph.rich_text[0].text.content).toBe("X")
+
+    expect(mockBlocks.children.append).toHaveBeenCalledTimes(1)
+    const appendCall = mockBlocks.children.append.mock.calls[0][0]
+    expect(appendCall.after).toBe("p1")
+    expect(appendCall.children).toHaveLength(1)
+    expect(appendCall.children[0].paragraph.rich_text[0].text.content).toBe("Y")
+  })
+
+  it("差分更新: 先頭に画像があれば head insert はその画像の後ろにアンカーされる", async () => {
+    // Old page: [imageA, p1 "Y"]. New: "X\nY"
+    // 期待: image はそのまま保持、新しい "X" は image の後ろ・p1 の前に挿入される。
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "img1", type: "image", image: { type: "file", file: { url: "https://x.com/a.png" }, caption: [] } },
+        { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "Y" }] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "X\nY")
+
+    // p1 ("Y") は keep されるので update も delete も無い
+    expect(mockBlocks.update).not.toHaveBeenCalled()
+    expect(mockBlocks.delete).not.toHaveBeenCalled()
+    // 画像の後ろに "X" を 1 つ append
+    expect(mockBlocks.children.append).toHaveBeenCalledTimes(1)
+    const appendCall = mockBlocks.children.append.mock.calls[0][0]
+    expect(appendCall.after).toBe("img1")
+    expect(appendCall.children).toHaveLength(1)
+    expect(appendCall.children[0].paragraph.rich_text[0].text.content).toBe("X")
+  })
+
+  it("差分更新: delete を挟んだ insert は 1 つの append にまとめる (順序逆転防止)", async () => {
+    // Old: [p1 "A", p2 "削除", p3 "B"], New: "A\nX\nY\nB"
+    // p1, p3 は keep。p2 は delete。X, Y は同じ region 内の insert。
+    // 別 group にすると後発の append が先発より前に入って X, Y の順序が壊れる。
+    mockBlocks.children.list.mockResolvedValue({
+      results: [
+        { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "A" }] } },
+        { id: "p2", type: "paragraph", paragraph: { rich_text: [{ plain_text: "削除" }] } },
+        { id: "p3", type: "paragraph", paragraph: { rich_text: [{ plain_text: "B" }] } },
+      ],
+      has_more: false,
+      next_cursor: null,
+    })
+
+    await updateTaskBlocks("page-1", "A\nX\nY\nB")
+
+    // 同 type ペアリングで p2 は delete ではなく update("X" or "Y") になる可能性が
+    // あるため、ここでは「append が呼ばれる場合、children の中で X→Y の順を保つ」
+    // ことだけを検証する。
+    const appendCalls = mockBlocks.children.append.mock.calls
+    const allAppendedTexts = appendCalls.flatMap(
+      (c: [{ children: Array<{ paragraph?: { rich_text: Array<{ text: { content: string } }> } }> }]) =>
+        c[0].children.map((b) => b.paragraph?.rich_text[0].text.content)
+    ).filter((t: string | undefined): t is string => typeof t === "string")
+    const xIdx = allAppendedTexts.indexOf("X")
+    const yIdx = allAppendedTexts.indexOf("Y")
+    if (xIdx !== -1 && yIdx !== -1) {
+      expect(xIdx).toBeLessThan(yIdx)
+    }
+  })
+
   it("差分更新: 末尾に1行追加したら delete なし、append は after なし1コール", async () => {
     mockBlocks.children.list.mockResolvedValue({
       results: [

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -602,7 +602,33 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
     const rawOps = lcsDiff(oldKeys, newKeys)
 
     // 4-2. 同位置・同 type の delete+insert を blocks.update に置換
-    const ops = pairUpdatesInPlace(rawOps, oldTextBlocks, newBlocks)
+    let ops = pairUpdatesInPlace(rawOps, oldTextBlocks, newBlocks)
+
+    // 4-3. 「先頭への insert」は anchor が無いと append が末尾に行ってしまい、
+    //      新しい行が body の最後に追記されてしまうため、対策する:
+    //      - 先頭テキストブロックより前の最後の image を anchor 候補として使う
+    //      - その image も無いなら、後続の keep/update を全て delete に降格させる
+    //        (= 旧来の delete-all + append-all に局所的にフォールバック)。
+    //        update へのペアリング最適化は再適用するので、典型ケースの API
+    //        コール数は大きく増えない。
+    const firstTextId = oldTextBlocks[0]?.id
+    let leadingImageAnchor: string | null = null
+    if (firstTextId) {
+      for (const b of oldBlocks) {
+        if (b.id === firstTextId) break
+        if ((b as { type: string }).type === "image") leadingImageAnchor = b.id
+      }
+    }
+    const firstAnchorIdx = ops.findIndex((o) => o.kind === "keep" || o.kind === "update")
+    const hasHeadInsert = firstAnchorIdx > 0 &&
+      ops.slice(0, firstAnchorIdx).some((o) => o.kind === "insert")
+    if (hasHeadInsert && leadingImageAnchor === null) {
+      const fallback: DiffOp[] = [
+        ...oldTextBlocks.map((_, i) => ({ kind: "delete" as const, oldIdx: i })),
+        ...newBlocks.map((_, i) => ({ kind: "insert" as const, newIdx: i })),
+      ]
+      ops = pairUpdatesInPlace(fallback, oldTextBlocks, newBlocks)
+    }
 
     // 5. delete 対象を集める
     const idsToDelete: string[] = []
@@ -612,24 +638,27 @@ export async function updateTaskBlocks(id: string, markdown: string): Promise<vo
 
     // 6. insert は連続するものを1コールにまとめ、直前の keep/update ブロック ID を after に指定。
     //    update は元のブロック ID を保つので、anchor として keep と同等に扱える。
-    //    keep/update が無いまま insert する場合は after なし（= ページ末尾に追加）。
+    //    delete を挟んでも anchor は変わらない (削除されたブロックは anchor に
+    //    使えないし、間に keep/update が無いなら新しい group を作る必要も無い:
+    //    複数 group が同一 anchor を共有すると並列実行で順序が逆転するため
+    //    1 group にまとめておく)。
+    //    冒頭の anchor は leadingImageAnchor (= 先頭画像) で初期化する。
     type InsertGroup = { after: string | null; payloads: object[] }
     const insertGroups: InsertGroup[] = []
     let currentGroup: InsertGroup | null = null
-    let lastAnchorId: string | null = null
+    let lastAnchorId: string | null = leadingImageAnchor
     for (const op of ops) {
       if (op.kind === "keep" || op.kind === "update") {
         lastAnchorId = oldTextBlocks[op.oldIdx].id
         currentGroup = null
-      } else if (op.kind === "delete") {
-        currentGroup = null
-      } else {
+      } else if (op.kind === "insert") {
         if (currentGroup === null) {
           currentGroup = { after: lastAnchorId, payloads: [] }
           insertGroups.push(currentGroup)
         }
         currentGroup.payloads.push(newBlocks[op.newIdx])
       }
+      // delete: anchor / group は変えない
     }
 
     // 7. delete / update / insert は別ブロックを触るので並走可。並列度 10 で実行。


### PR DESCRIPTION
## Summary

LCS 差分ベースの本文更新で「**先頭への insert** (= 先頭の keep/update より前にある insert)」が anchor 無しで append され、結果として新しい行が body の末尾に追記されてしまうバグを修正。

ユーザー報告: 「タスク本文、更新すると更新した内容が末尾に追記されてしまう」

## 原因

\`blocks.children.append\` は \`after\` 無しだと **常にページ末尾** に追加される。LCS 差分が \`[insert(0), keep(0,1)]\` のような ops を返したとき、insert(0) には先行する keep が無く anchor を取れずに末尾行きになっていた。

## 修正

1. 先頭テキストブロックより前の最後の image を anchor 候補として使う（画像があればその後ろに挿入）
2. 該当 image が無いケースは、後続の keep/update を全て delete に降格させて旧来の delete-all + append-all へ局所フォールバック。同 type 置換は \`pairUpdatesInPlace\` で update に再最適化されるので、典型ケース（"X" を先頭に追加） は \`update p1 to "X"\` + \`append "Y" after p1\` の **2 コール** に収まる

## 副次修正

\`delete\` を挟んだ \`insert\` が別 group に分裂すると、同一 anchor へ複数の append が発行される。並列実行で順序が逆転しうるため、insert group は delete を跨いでも継続するように変更。

## Test plan

- [x] \`npm run test:unit\` 245 passed (+3 件: 先頭追加バグ再現/leading-image アンカー/順序保証)
- [x] \`npx playwright test\` 35 passed
- [ ] 本番で本文の先頭に行を追加 → 末尾に追記されず先頭に正しく入ることを確認
- [ ] 中間編集など既存の差分挙動が引き続き正しく動くことを確認