### PR TITLE
perf(tasks): 完了ステータスを初回 fetch から除外、完了カラム表示時に lazy load

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -4,8 +4,8 @@ import { updateTag } from "next/cache"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { auth } from "@/auth"
-import { updateTask, createTask, getTaskBlocks, updateTaskBlocks, getTaskComments, createTaskComment } from "@/lib/notion"
-import type { AdvancedFilter, SortConfig, TaskStatus, TaskComment, CreateTaskInput, UpdateTaskInput } from "@/types/task"
+import { updateTask, createTask, getTaskBlocks, updateTaskBlocks, getTaskComments, createTaskComment, getTasks } from "@/lib/notion"
+import type { AdvancedFilter, SortConfig, Task, TaskStatus, TaskComment, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 
 function isDevMode() {
   return process.env.NODE_ENV === "development" || process.env.NEXTJS_ENV === "development"
@@ -51,6 +51,11 @@ export async function updateTaskAction(id: string, input: UpdateTaskInput) {
 export async function refreshTasksAction() {
   await requireAuth()
   updateTag("tasks")
+}
+
+export async function getCompletedTasksAction(): Promise<Task[]> {
+  await requireAuth()
+  return getTasks({ statuses: ["完了"] })
 }
 
 export async function getTaskBlocksAction(id: string): Promise<string> {

--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useMemo } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import type { AdvancedFilter, SortConfig, Task, TaskStatus } from "@/types/task"
 import { TaskItem } from "./TaskItem"
 import { applyAdvancedFilter } from "@/constants/filters"
 import { applySort } from "@/lib/task-sort"
+import { getCompletedTasksAction } from "@/app/actions"
 
 const STATUS_ACCENT: Record<TaskStatus, string> = {
   "未着手":         "var(--status-todo)",
@@ -31,18 +32,62 @@ export function BoardColumn({
   sort: SortConfig
   onSelect: (id: string) => void
 }) {
+  // 完了カラムは初回ページ取得から除外しているため、カラムが viewport に
+  // 入ったタイミングで一度だけ fetch する (ページ初期化を軽くする目的)。
+  // ただし tasks prop が既に完了タスクを含む場合 (= テスト/明示的 fetch 済み)
+  // はそれをそのまま使い、lazy load はスキップする。
+  const isCompleted = status === "完了"
+  const propCompletedTasks = useMemo(
+    () => (isCompleted ? tasks.filter((t) => t.status === "完了") : []),
+    [isCompleted, tasks]
+  )
+  const propsHasCompleted = propCompletedTasks.length > 0
+  const [lazyTasks, setLazyTasks] = useState<Task[] | null>(null)
+  const [isLoadingLazy, setIsLoadingLazy] = useState(false)
+  const [hasLoadError, setHasLoadError] = useState(false)
+  const sectionRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    if (!isCompleted) return
+    if (propsHasCompleted) return
+    if (lazyTasks !== null) return
+    const el = sectionRef.current
+    if (!el) return
+    if (typeof IntersectionObserver === "undefined") return
+    const obs = new IntersectionObserver((entries) => {
+      if (!entries.some((e) => e.isIntersecting)) return
+      obs.disconnect()
+      setIsLoadingLazy(true)
+      getCompletedTasksAction()
+        .then((t) => setLazyTasks(t))
+        .catch(() => setHasLoadError(true))
+        .finally(() => setIsLoadingLazy(false))
+    }, { threshold: 0.05 })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [isCompleted, propsHasCompleted, lazyTasks])
+
   const q = searchQuery.trim().toLowerCase()
   const filtered = useMemo(() => {
-    const byStatus = tasks.filter((t) => t.status === status)
-    const byAdvanced = applyAdvancedFilter(byStatus, advancedFilter)
+    let source: Task[]
+    if (isCompleted) {
+      source = propsHasCompleted ? propCompletedTasks : (lazyTasks ?? [])
+    } else {
+      source = tasks.filter((t) => t.status === status)
+    }
+    const byAdvanced = applyAdvancedFilter(source, advancedFilter)
     const bySearch = q === "" ? byAdvanced : byAdvanced.filter((t) => t.title.toLowerCase().includes(q))
     return applySort(bySearch, sort)
-  }, [tasks, status, advancedFilter, q, sort])
+  }, [isCompleted, propsHasCompleted, propCompletedTasks, lazyTasks, tasks, status, advancedFilter, q, sort])
 
   const accent = STATUS_ACCENT[status]
+  const isLazyPending = isCompleted && !propsHasCompleted && lazyTasks === null
+  const showLazyLoading = isLazyPending && !hasLoadError
+  const showLazyError = isLazyPending && hasLoadError
 
   return (
     <section
+      ref={sectionRef}
       data-testid="board-column"
       data-status={status}
       className="flex-shrink-0 w-[360px] h-full flex flex-col snap-start"
@@ -60,12 +105,20 @@ export function BoardColumn({
           {status}
         </span>
         <span className="font-pixel text-[11px] text-[var(--text-faint)] tabular-nums">
-          {filtered.length}
+          {isLazyPending ? "" : filtered.length}
         </span>
       </header>
 
       <div className="flex-1 overflow-y-auto overscroll-contain px-3 py-3">
-        {filtered.length === 0 ? (
+        {showLazyLoading ? (
+          <p className="font-pixel text-center text-[var(--text-faint)] text-[11px] py-6 tracking-widest">
+            — LOADING —
+          </p>
+        ) : showLazyError ? (
+          <p className="font-pixel text-center text-[var(--status-cancel)] text-[11px] py-6 tracking-widest">
+            — LOAD FAILED —
+          </p>
+        ) : filtered.length === 0 ? (
           <p className="font-pixel text-center text-[var(--text-faint)] text-[11px] py-6 tracking-widest">
             {q !== "" ? "— NO MATCH —" : "—"}
           </p>

--- a/src/lib/__tests__/notion.test.ts
+++ b/src/lib/__tests__/notion.test.ts
@@ -353,6 +353,22 @@ describe("getTasks", () => {
     expect(statuses).toContain("進行中")
   })
 
+  it("デフォルトでは完了ステータスは取得しない (lazy load 用)", async () => {
+    mockDataSources.query.mockResolvedValue({ results: [] })
+    await getTasks()
+    const call = mockDataSources.query.mock.calls[0][0]
+    const statuses = call.filter.or.map((f: { status: { equals: string } }) => f.status.equals)
+    expect(statuses).not.toContain("完了")
+  })
+
+  it("statuses: ['完了'] を明示すると完了のみ取得する", async () => {
+    mockDataSources.query.mockResolvedValue({ results: [] })
+    await getTasks({ statuses: ["完了"] })
+    const call = mockDataSources.query.mock.calls[0][0]
+    const statuses = call.filter.or.map((f: { status: { equals: string } }) => f.status.equals)
+    expect(statuses).toEqual(["完了"])
+  })
+
   it("statuses オプションで任意のフィルターを渡せる", async () => {
     mockDataSources.query.mockResolvedValue({ results: [] })
     await getTasks({ statuses: ["確認中", "一時中断"] })

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -123,15 +123,14 @@ async function fetchTasks(statuses: TaskStatus[]): Promise<Task[]> {
   }
 }
 
-// Notion ボードビューでは全ステータス（"アーカイブ済み" を除く）を一括取得して
-// クライアント側でカラムごとにグルーピングする。
-const BOARD_STATUSES: TaskStatus[] = ["未着手", "進行中", "確認中", "一時中断", "完了", "中止"]
+// 初回レンダで取得するステータス。完了は件数が多くなりがちなので、
+// 完了カラムが画面に出たときに別途 fetch するようにし、初回コストを下げる。
+const INITIAL_STATUSES: TaskStatus[] = ["未着手", "進行中", "確認中", "一時中断", "中止"]
 
 export function getTasks(options?: {
   statuses?: TaskStatus[]
-  includeCompleted?: boolean
 }): Promise<Task[]> {
-  const statuses: TaskStatus[] = options?.statuses ?? BOARD_STATUSES
+  const statuses: TaskStatus[] = options?.statuses ?? INITIAL_STATUSES
   if (isDevMode()) return Promise.resolve(getMockTasks(statuses))
   return unstable_cache(
     () => fetchTasks(statuses),


### PR DESCRIPTION
## Summary

完了タスクは件数が膨らみやすくページ初回ロードを重くしていたので、
初回 fetch から除外して完了カラムが画面に出たタイミングでだけ取得する。

- \`getTasks()\` のデフォルト統計を \`INITIAL_STATUSES\` (完了を含まない 5 statuses) に変更
- \`getCompletedTasksAction\` を新設 (\`getTasks({ statuses: ["完了"] })\` ラッパ)
- \`BoardColumn\` の完了カラムは \`IntersectionObserver\` でカラム可視を検知 → 初回のみ \`getCompletedTasksAction\` を呼ぶ
- ロード中: "— LOADING —" / 失敗: "— LOAD FAILED —"
- \`tasks\` prop に既に完了タスクが含まれる場合 (テスト/明示 fetch 済み) は lazy load をスキップして prop をそのまま使う (既存テスト互換)

## 既知の制限

- 完了カラムは初回 fetch 後はキャッシュ。タスクを完了にしても、完了カラムは自動 refetch しない (= ページ再読み込みで反映)。
  v2 で「タスクが完了になったら完了カラムを invalidate」する手当ても可能だが、初回パフォーマンス改善が主目的のため今回は見送り。

## Test plan

- [x] \`npm run test:unit\` 247 passed (+2 件: 完了がデフォルトに含まれない / 明示指定で完了のみ取得)
- [x] \`npx playwright test\` 35 passed
- [ ] 本番で初回ロードが速くなっていることを体感
- [ ] 完了カラムをスクロール表示すると LOADING → タスク一覧、と遷移することを確認
- [ ] 検索クエリ入力時、完了カラム未ロードでは検索対象に入らないこと (= 仕様) を確認