### PR TITLE
perf(tasks): 中止カラムも lazy load 化

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -58,6 +58,11 @@ export async function getCompletedTasksAction(): Promise<Task[]> {
   return getTasks({ statuses: ["完了"] })
 }
 
+export async function getCancelledTasksAction(): Promise<Task[]> {
+  await requireAuth()
+  return getTasks({ statuses: ["中止"] })
+}
+
 export async function getTaskBlocksAction(id: string): Promise<string> {
   await requireAuth()
   return getTaskBlocks(id)

--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -5,7 +5,7 @@ import type { AdvancedFilter, SortConfig, Task, TaskStatus } from "@/types/task"
 import { TaskItem } from "./TaskItem"
 import { applyAdvancedFilter } from "@/constants/filters"
 import { applySort } from "@/lib/task-sort"
-import { getCompletedTasksAction } from "@/app/actions"
+import { getCompletedTasksAction, getCancelledTasksAction } from "@/app/actions"
 
 const STATUS_ACCENT: Record<TaskStatus, string> = {
   "未着手":         "var(--status-todo)",
@@ -32,56 +32,57 @@ export function BoardColumn({
   sort: SortConfig
   onSelect: (id: string) => void
 }) {
-  // 完了カラムは初回ページ取得から除外しているため、カラムが viewport に
+  // 完了/中止カラムは初回ページ取得から除外しているため、カラムが viewport に
   // 入ったタイミングで一度だけ fetch する (ページ初期化を軽くする目的)。
-  // ただし tasks prop が既に完了タスクを含む場合 (= テスト/明示的 fetch 済み)
-  // はそれをそのまま使い、lazy load はスキップする。
-  const isCompleted = status === "完了"
-  const propCompletedTasks = useMemo(
-    () => (isCompleted ? tasks.filter((t) => t.status === "完了") : []),
-    [isCompleted, tasks]
+  // ただし tasks prop が既に該当ステータスのタスクを含む場合
+  // (= テスト/明示的 fetch 済み) はそれをそのまま使い、lazy load はスキップする。
+  const isLazyStatus = status === "完了" || status === "中止"
+  const propLazyTasks = useMemo(
+    () => (isLazyStatus ? tasks.filter((t) => t.status === status) : []),
+    [isLazyStatus, status, tasks]
   )
-  const propsHasCompleted = propCompletedTasks.length > 0
+  const propsHasLazy = propLazyTasks.length > 0
   const [lazyTasks, setLazyTasks] = useState<Task[] | null>(null)
   const [isLoadingLazy, setIsLoadingLazy] = useState(false)
   const [hasLoadError, setHasLoadError] = useState(false)
   const sectionRef = useRef<HTMLElement>(null)
 
   useEffect(() => {
-    if (!isCompleted) return
-    if (propsHasCompleted) return
+    if (!isLazyStatus) return
+    if (propsHasLazy) return
     if (lazyTasks !== null) return
     const el = sectionRef.current
     if (!el) return
     if (typeof IntersectionObserver === "undefined") return
+    const fetcher = status === "完了" ? getCompletedTasksAction : getCancelledTasksAction
     const obs = new IntersectionObserver((entries) => {
       if (!entries.some((e) => e.isIntersecting)) return
       obs.disconnect()
       setIsLoadingLazy(true)
-      getCompletedTasksAction()
+      fetcher()
         .then((t) => setLazyTasks(t))
         .catch(() => setHasLoadError(true))
         .finally(() => setIsLoadingLazy(false))
     }, { threshold: 0.05 })
     obs.observe(el)
     return () => obs.disconnect()
-  }, [isCompleted, propsHasCompleted, lazyTasks])
+  }, [isLazyStatus, propsHasLazy, lazyTasks, status])
 
   const q = searchQuery.trim().toLowerCase()
   const filtered = useMemo(() => {
     let source: Task[]
-    if (isCompleted) {
-      source = propsHasCompleted ? propCompletedTasks : (lazyTasks ?? [])
+    if (isLazyStatus) {
+      source = propsHasLazy ? propLazyTasks : (lazyTasks ?? [])
     } else {
       source = tasks.filter((t) => t.status === status)
     }
     const byAdvanced = applyAdvancedFilter(source, advancedFilter)
     const bySearch = q === "" ? byAdvanced : byAdvanced.filter((t) => t.title.toLowerCase().includes(q))
     return applySort(bySearch, sort)
-  }, [isCompleted, propsHasCompleted, propCompletedTasks, lazyTasks, tasks, status, advancedFilter, q, sort])
+  }, [isLazyStatus, propsHasLazy, propLazyTasks, lazyTasks, tasks, status, advancedFilter, q, sort])
 
   const accent = STATUS_ACCENT[status]
-  const isLazyPending = isCompleted && !propsHasCompleted && lazyTasks === null
+  const isLazyPending = isLazyStatus && !propsHasLazy && lazyTasks === null
   const showLazyLoading = isLazyPending && !hasLoadError
   const showLazyError = isLazyPending && hasLoadError
 

--- a/src/lib/__tests__/notion.test.ts
+++ b/src/lib/__tests__/notion.test.ts
@@ -353,12 +353,13 @@ describe("getTasks", () => {
     expect(statuses).toContain("進行中")
   })
 
-  it("デフォルトでは完了ステータスは取得しない (lazy load 用)", async () => {
+  it("デフォルトでは完了/中止ステータスは取得しない (lazy load 用)", async () => {
     mockDataSources.query.mockResolvedValue({ results: [] })
     await getTasks()
     const call = mockDataSources.query.mock.calls[0][0]
     const statuses = call.filter.or.map((f: { status: { equals: string } }) => f.status.equals)
     expect(statuses).not.toContain("完了")
+    expect(statuses).not.toContain("中止")
   })
 
   it("statuses: ['完了'] を明示すると完了のみ取得する", async () => {
@@ -367,6 +368,14 @@ describe("getTasks", () => {
     const call = mockDataSources.query.mock.calls[0][0]
     const statuses = call.filter.or.map((f: { status: { equals: string } }) => f.status.equals)
     expect(statuses).toEqual(["完了"])
+  })
+
+  it("statuses: ['中止'] を明示すると中止のみ取得する", async () => {
+    mockDataSources.query.mockResolvedValue({ results: [] })
+    await getTasks({ statuses: ["中止"] })
+    const call = mockDataSources.query.mock.calls[0][0]
+    const statuses = call.filter.or.map((f: { status: { equals: string } }) => f.status.equals)
+    expect(statuses).toEqual(["中止"])
   })
 
   it("statuses オプションで任意のフィルターを渡せる", async () => {

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -123,9 +123,9 @@ async function fetchTasks(statuses: TaskStatus[]): Promise<Task[]> {
   }
 }
 
-// 初回レンダで取得するステータス。完了は件数が多くなりがちなので、
-// 完了カラムが画面に出たときに別途 fetch するようにし、初回コストを下げる。
-const INITIAL_STATUSES: TaskStatus[] = ["未着手", "進行中", "確認中", "一時中断", "中止"]
+// 初回レンダで取得するステータス。完了/中止は件数が多くなりがちなので、
+// 該当カラムが画面に出たときに別途 fetch するようにし、初回コストを下げる。
+const INITIAL_STATUSES: TaskStatus[] = ["未着手", "進行中", "確認中", "一時中断"]
 
 export function getTasks(options?: {
   statuses?: TaskStatus[]


### PR DESCRIPTION
## Summary

PR #80 と同じパターンを中止ステータスにも適用し、初回 fetch から外す。

- \`INITIAL_STATUSES\` から中止を除外 (= \`[未着手, 進行中, 確認中, 一時中断]\` の 4 つに)
- \`getCancelledTasksAction\` を新設
- \`BoardColumn\` の lazy 判定を \`status === "完了" || status === "中止"\` に拡張、status に応じて fetcher を切り替え

## Test plan

- [x] \`npm run test:unit\` 248 passed (+1 件: 中止のみ取得)
- [x] \`npx playwright test\` 35 passed
- [ ] 本番で初回ロードが更に速くなっていることを体感
- [ ] 中止カラムをスクロール表示すると LOADING → タスク一覧、と遷移することを確認