### PR TITLE
fix(refresh): タブ復帰時の自動リフレッシュが効かないバグを修正

### DIFF
--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -68,6 +68,19 @@ export function BoardColumn({
     return () => obs.disconnect()
   }, [isLazyStatus, propsHasLazy, lazyTasks, status])
 
+  // タブ復帰時に lazy state をクリアして、再びカラムが見えたら fetch しなおす。
+  // (TaskManager 側の router.refresh() ではローカル state は消えないので個別に対応)
+  useEffect(() => {
+    if (!isLazyStatus) return
+    function onVisible() {
+      if (document.visibilityState !== "visible") return
+      setLazyTasks(null)
+      setHasLoadError(false)
+    }
+    document.addEventListener("visibilitychange", onVisible)
+    return () => document.removeEventListener("visibilitychange", onVisible)
+  }, [isLazyStatus])
+
   const q = searchQuery.trim().toLowerCase()
   const filtered = useMemo(() => {
     let source: Task[]

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useTransition, useEffect, useRef } from "react"
+import { useRouter } from "next/navigation"
 import type { AdvancedFilter, SortConfig, Task } from "@/types/task"
 import { TaskBoard } from "./TaskBoard"
 import { TaskDetail } from "./TaskDetail"
@@ -54,17 +55,23 @@ export function TaskManager({
   const selectedTask = selectedTaskId ? tasks.find((t) => t.id === selectedTaskId) ?? null : null
 
   // ─── Refresh on visibility change ─────────────────────────────────────────
+  // updateTag だけではサーバーキャッシュを無効化するのみで RSC 再描画はトリガ
+  // されないことがあるため、router.refresh() で明示的にツリーを再取得する。
+  const router = useRouter()
   const isPendingRef = useRef(false)
   useEffect(() => { isPendingRef.current = isPending }, [isPending])
   useEffect(() => {
     function onVisible() {
       if (document.visibilityState !== "visible") return
       if (isPendingRef.current) return
-      startTransition(async () => { await refreshTasksAction() })
+      startTransition(async () => {
+        await refreshTasksAction()
+        router.refresh()
+      })
     }
     document.addEventListener("visibilitychange", onVisible)
     return () => document.removeEventListener("visibilitychange", onVisible)
-  }, [])
+  }, [router])
 
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
@@ -148,7 +155,7 @@ export function TaskManager({
         <button
           data-testid="refresh-button"
           disabled={isPending}
-          onClick={() => startTransition(async () => { await refreshTasksAction() })}
+          onClick={() => startTransition(async () => { await refreshTasksAction(); router.refresh() })}
           className="flex-shrink-0 w-9 h-9 rounded-lg border border-[var(--border-strong)] bg-[var(--surface)] text-[var(--accent)] flex items-center justify-center hover:border-[var(--accent)] active:scale-95 disabled:opacity-40 transition-colors"
           aria-label="再読み込み"
         >

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -10,6 +10,10 @@ vi.mock("@/app/actions", () => ({
   refreshTasksAction: vi.fn().mockResolvedValue(undefined),
 }))
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), replace: vi.fn() }),
+}))
+
 // TaskItem は描画内容ではなくボード分配ロジックを検証するため簡略化
 vi.mock("@/components/TaskItem", () => ({
   TaskItem: ({ task }: { task: Task }) => (


### PR DESCRIPTION
## Summary

ユーザー報告: 「画面表示時に自動でリフレッシュする機能、動いてない気がする」

## 原因

\`TaskManager.tsx:56-67\` に visibilitychange ハンドラがあり \`refreshTasksAction\` を呼んでいたが、以下 2 点で UI に反映されていなかった:

1. **\`updateTag("tasks")\` だけでは RSC 再描画されない**
   - サーバー側のキャッシュタグ無効化はされるが、Next.js の自動 route refresh は form 経由のサーバーアクション以外だと走らないことがある
   - 関数呼び出し型の場合は \`router.refresh()\` を明示的に呼ぶ必要があった

2. **完了/中止カラムは BoardColumn のローカル state で握っている**
   - PR #80 / #81 の lazy load 化で、完了/中止タスクは \`BoardColumn\` 内の \`lazyTasks\` state に保持されている
   - ページ再描画ではローカル state は消えないため、タスクが完了/中止に遷移しても古い lazy state が表示され続ける

## Fix

- \`TaskManager\` の visibilitychange ハンドラと手動リフレッシュボタンに \`router.refresh()\` を追加
- \`BoardColumn\` (lazy status のみ) も visibilitychange を購読し、復帰時に \`lazyTasks = null\` にリセット → 再可視化で IntersectionObserver が再 fetch をトリガ

## Test plan

- [x] \`npm run test:unit\` 248 passed
- [x] \`npx playwright test\` 35 passed
- [ ] 本番でタスクを Notion 側で編集 → アプリのタブに戻ると反映されることを確認
- [ ] タスクのステータスを完了に変更 → タブを切り替えて戻ると完了カラムにも反映されることを確認