### PR TITLE
fix(cache): unstable_cache を撤去 — 本番でステータス更新/作成が反映されないバグを修正

### DIFF
--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,4 +1,3 @@
-import { unstable_cache } from "next/cache"
 import { Client } from "@notionhq/client"
 import type { PageObjectResponse, BlockObjectResponse, PartialBlockObjectResponse, CommentObjectResponse } from "@notionhq/client/build/src/api-endpoints"
 import type { Task, TaskComment, TaskPriority, TaskStatus, CreateTaskInput, UpdateTaskInput } from "@/types/task"
@@ -127,16 +126,15 @@ async function fetchTasks(statuses: TaskStatus[]): Promise<Task[]> {
 // 該当カラムが画面に出たときに別途 fetch するようにし、初回コストを下げる。
 const INITIAL_STATUSES: TaskStatus[] = ["未着手", "進行中", "確認中", "一時中断"]
 
+// Cloudflare Workers (open-next) では tagCache 未設定時に updateTag が no-op に
+// なり、unstable_cache の値が永久に古くなる。個人用アプリで Notion API 呼び
+// 出しを毎回行ってもコストは小さいため、キャッシュを使わず常に直接 fetch する。
 export function getTasks(options?: {
   statuses?: TaskStatus[]
 }): Promise<Task[]> {
   const statuses: TaskStatus[] = options?.statuses ?? INITIAL_STATUSES
   if (isDevMode()) return Promise.resolve(getMockTasks(statuses))
-  return unstable_cache(
-    () => fetchTasks(statuses),
-    ["tasks", statuses.join(",")],
-    { tags: ["tasks"] }
-  )()
+  return fetchTasks(statuses)
 }
 
 async function fetchTagOptions(): Promise<string[]> {
@@ -154,11 +152,7 @@ async function fetchTagOptions(): Promise<string[]> {
 
 export function getTagOptions(): Promise<string[]> {
   if (isDevMode()) return Promise.resolve(getMockTagOptions())
-  return unstable_cache(
-    fetchTagOptions,
-    ["tag-options"],
-    { tags: ["tasks"] }
-  )()
+  return fetchTagOptions()
 }
 
 export async function getTask(id: string): Promise<Task | null> {


### PR DESCRIPTION
## Summary
本番 (Cloudflare Workers) でタスクのステータス変更や新規作成が UI に反映されないバグを修正。

## 原因
`open-next.config.ts` で `tagCache` を設定していないため、`defineCloudflareConfig` のデフォルト (\`\"dummy\"\`) が適用され、\`updateTag\` が no-op になっていた。結果:

1. \`updateTaskStatus\` 等が \`updateTag(\"tasks\")\` を呼ぶ → 何もしない
2. \`fetchInitialDataAction\` が \`unstable_cache\` の古い値を返し続ける
3. UI が永久に古い状態のまま (= 「ステータスが反映されない」「タスクが追加されない」)

dev モードでは \`getTasks\`/\`getTagOptions\` が \`unstable_cache\` をバイパスして直接 mock store を読むため再現せず、Playwright (dev) でも検出できなかった。

## 修正
個人用アプリで Notion API を毎リクエスト呼んでもコストは小さいため、\`getTasks\` / \`getTagOptions\` から \`unstable_cache\` を撤去し、常に直接 fetch する。

代替案 (D1/KV/DO で tagCache を構成) より変更がはるかに小さく、キャッシュ整合性の問題が根本的に消える。

## Test plan
- [x] \`npm run test:unit\` (249 / 249)
- [x] \`npx playwright test\` (35 / 35)
- [ ] 本番デプロイ後、ステータス変更・タスク作成が即時反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)