### PR TITLE
perf(task-icon): file icon を /api/icon proxy にしてエッジキャッシュ可能化

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,5 +17,5 @@ export default auth((req) => {
 })
 
 export const config = {
-  matcher: ["/((?!api/auth|api/login|_next/static|_next/image|favicon.ico|manifest.webmanifest|icon-192|icon-512).*)"],
+  matcher: ["/((?!api/auth|api/login|api/icon|_next/static|_next/image|favicon.ico|manifest.webmanifest|icon-192|icon-512).*)"],
 }

--- a/src/app/api/icon/[pageId]/route.ts
+++ b/src/app/api/icon/[pageId]/route.ts
@@ -1,0 +1,72 @@
+import { type NextRequest } from "next/server"
+import { Client } from "@notionhq/client"
+import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints"
+import { config } from "@/config"
+
+// Notion の file icon は署名付き S3 URL で、リクエストごとに署名トークンが変わり
+// ブラウザキャッシュが効かない。本ルートは pageId をキーにした安定 URL を提供し、
+// Cloudflare Workers の caches.default で 30 日キャッシュしてエッジ配信する。
+
+const IMMUTABLE_CACHE = "public, max-age=2592000, s-maxage=2592000, immutable"
+const NEGATIVE_CACHE = "public, max-age=300, s-maxage=300"
+
+const PAGE_ID_RE = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i
+
+function getEdgeCache(): Cache | null {
+  const c = (globalThis as { caches?: { default?: Cache } }).caches
+  return c?.default ?? null
+}
+
+async function resolveIconUrl(pageId: string): Promise<string | null> {
+  const notion = new Client({ auth: config.notion.token })
+  const page = (await notion.pages.retrieve({ page_id: pageId })) as PageObjectResponse
+  const icon = page.icon
+  if (!icon) return null
+  if (icon.type === "file") return icon.file.url
+  if (icon.type === "external") return icon.external.url
+  return null
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ pageId: string }> },
+) {
+  const { pageId } = await params
+  if (!PAGE_ID_RE.test(pageId)) return new Response(null, { status: 400 })
+
+  const cache = getEdgeCache()
+  const cacheKey = new Request(req.url, { method: "GET" })
+
+  if (cache) {
+    const hit = await cache.match(cacheKey)
+    if (hit) return hit
+  }
+
+  let iconUrl: string | null = null
+  try {
+    iconUrl = await resolveIconUrl(pageId)
+  } catch (e) {
+    console.error("[/api/icon] notion error:", e)
+  }
+
+  if (!iconUrl) {
+    const res = new Response(null, { status: 404, headers: { "cache-control": NEGATIVE_CACHE } })
+    if (cache) await cache.put(cacheKey, res.clone())
+    return res
+  }
+
+  const upstream = await fetch(iconUrl)
+  if (!upstream.ok) return new Response(null, { status: 502 })
+
+  const contentType = upstream.headers.get("content-type") ?? "image/png"
+  const bytes = await upstream.arrayBuffer()
+  const res = new Response(bytes, {
+    status: 200,
+    headers: {
+      "content-type": contentType,
+      "cache-control": IMMUTABLE_CACHE,
+    },
+  })
+  if (cache) await cache.put(cacheKey, res.clone())
+  return res
+}

--- a/src/lib/__tests__/notion.test.ts
+++ b/src/lib/__tests__/notion.test.ts
@@ -48,6 +48,8 @@ function makePage(overrides: {
   childIds?: { id: string }[]
   prevIds?: { id: string }[]
   nextIds?: { id: string }[]
+  icon?: PageObjectResponse["icon"]
+  lastEditedTime?: string
 } = {}): PageObjectResponse {
   const d = {
     id: "page-1",
@@ -64,6 +66,8 @@ function makePage(overrides: {
     childIds: [],
     prevIds: [],
     nextIds: [],
+    icon: null,
+    lastEditedTime: "2024-01-02T00:00:00.000Z",
     ...overrides,
   }
   return {
@@ -71,9 +75,9 @@ function makePage(overrides: {
     id: d.id,
     url: d.url,
     created_time: "2024-01-01T00:00:00.000Z",
-    last_edited_time: "2024-01-02T00:00:00.000Z",
+    last_edited_time: d.lastEditedTime,
     cover: null,
-    icon: null,
+    icon: d.icon,
     parent: { type: "database_id", database_id: "db-1" },
     archived: false,
     in_trash: false,
@@ -319,6 +323,56 @@ describe("getTask", () => {
     mockPages.retrieve.mockResolvedValue(page)
     const task = await getTask("id-1")
     expect(task?.parentTaskIds).toEqual([])
+  })
+
+  // --- extractIcon の検証 ---
+
+  it("icon が null の場合 task.icon は null", async () => {
+    mockPages.retrieve.mockResolvedValue(makePage({ icon: null }))
+    const task = await getTask("id-1")
+    expect(task?.icon).toBeNull()
+  })
+
+  it("emoji icon はそのまま返す", async () => {
+    mockPages.retrieve.mockResolvedValue(
+      makePage({ icon: { type: "emoji", emoji: "🌐" } as unknown as PageObjectResponse["icon"] })
+    )
+    const task = await getTask("id-1")
+    expect(task?.icon).toEqual({ type: "emoji", emoji: "🌐" })
+  })
+
+  it("file icon は /api/icon proxy URL に書き換えられる (署名 URL を直接渡さない)", async () => {
+    mockPages.retrieve.mockResolvedValue(
+      makePage({
+        id: "abc-123",
+        lastEditedTime: "2024-05-01T12:00:00.000Z",
+        icon: {
+          type: "file",
+          file: { url: "https://prod-files-secure.s3.us-west-2.amazonaws.com/x?X-Amz-Signature=abc" },
+        } as unknown as PageObjectResponse["icon"],
+      })
+    )
+    const task = await getTask("abc-123")
+    expect(task?.icon).toEqual({
+      type: "url",
+      url: "/api/icon/abc-123?v=2024-05-01T12%3A00%3A00.000Z",
+    })
+  })
+
+  it("external icon は元 URL のまま返す (既に CDN にある想定)", async () => {
+    mockPages.retrieve.mockResolvedValue(
+      makePage({
+        icon: {
+          type: "external",
+          external: { url: "https://www.notion.so/icons/database_blue.svg" },
+        } as unknown as PageObjectResponse["icon"],
+      })
+    )
+    const task = await getTask("id-1")
+    expect(task?.icon).toEqual({
+      type: "url",
+      url: "https://www.notion.so/icons/database_blue.svg",
+    })
   })
 })
 

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -62,11 +62,21 @@ function extractSourceUrl(props: PageObjectResponse["properties"]): string | nul
   return p?.url ?? null
 }
 
-function extractIcon(icon: PageObjectResponse["icon"]): TaskIcon | null {
+function extractIcon(
+  icon: PageObjectResponse["icon"],
+  pageId: string,
+  lastEditedTime: string,
+): TaskIcon | null {
   if (!icon) return null
   if (icon.type === "emoji") return { type: "emoji", emoji: icon.emoji }
+  // file (Notion S3 署名 URL) はリクエストごとに署名が変わりブラウザキャッシュが
+  // 効かないため、pageId をキーにした安定 proxy URL に置き換える。
+  // v に last_edited_time を載せることで、ページ更新時にキャッシュが自然に切れる。
+  if (icon.type === "file") {
+    return { type: "url", url: `/api/icon/${pageId}?v=${encodeURIComponent(lastEditedTime)}` }
+  }
+  // external は Notion 提供 CDN や任意 URL。すでにブラウザキャッシュが効くのでそのまま。
   if (icon.type === "external") return { type: "url", url: icon.external.url }
-  if (icon.type === "file") return { type: "url", url: icon.file.url }
   return null
 }
 
@@ -76,7 +86,7 @@ function pageToTask(page: PageObjectResponse): Task {
     id: page.id,
     url: page.url,
     title:        extractTitle(props),
-    icon:         extractIcon(page.icon),
+    icon:         extractIcon(page.icon, page.id, page.last_edited_time),
     status:       extractStatus(props),
     priority:     extractPriority(props),
     due:          extractDueDate(props),


### PR DESCRIPTION
## Summary
- Notion の file icon は署名付き S3 URL でリクエストごとに署名が変わるため、タスク一覧を再フェッチするたびにブラウザキャッシュが完全に失われ、毎回 US-West の S3 にラウンドトリップしていた
- pageId をキーにした安定 URL `/api/icon/:pageId?v=<lastEditedTime>` に置き換え、Workers の `caches.default` で 30 日キャッシュする
- 結果: ① 同一 (pageId, lastEditedTime) は CF エッジから即配信 ② 安定 URL なのでブラウザキャッシュも効く (2 回目以降はネットワーク無し) ③ `v` に `last_edited_time` を載せ、ページ更新時に自然に invalidate される
- external icon は元 URL のまま (Notion 提供の CDN にあり proxy 不要)
- middleware は `/api/icon` を除外 (page UUID が事実上の capability key)

## Test plan
- [x] `npm run test:unit` — 253 件パス (extractIcon の file proxy 化 / external 維持 / emoji そのまま / null の 4 ケース追加)
- [x] `npx playwright test` — 非スナップショットの 32 件パス。スナップショット 3 件は main でも同様に失敗するベースラインドリフトで本 PR とは無関係
- [ ] Production デプロイ後、`Network` タブで `/api/icon/...` が 2 回目以降 `(disk cache)` になることを確認
- [ ] CF ダッシュボードで `/api/icon/*` のキャッシュヒット率を確認