### PR TITLE
fix(board-column): リスト下端の余白を 16 → 44px に拡張 (iPhone セーフエリア回避)

### DIFF
--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -173,7 +173,7 @@ export function BoardColumn({
         </span>
       </header>
 
-      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overscroll-contain px-4 pt-4 pb-11">
         {showLazyLoading ? (
           <p className="font-pixel text-center text-[var(--text-faint)] text-[11px] py-6 tracking-widest">
             — LOADING —


### PR DESCRIPTION
## Summary
- 各カラムの scroll container (`BoardColumn.tsx`) は `py-4` (16px) で上下対称だったが、iPhone の Home Indicator (セーフエリア下 ~34px) と被って最下のタスクカードが視認しづらかった
- `pt-4 pb-11` に分割し、下端の余白だけ **44px に拡張**。Home Indicator 上に約 10px の breathing room を確保
- 上端は `pt-4` 据え置き (sticky ヘッダ直下なので変更不要)

## Test plan
- [x] `npm run test:unit` — 253 件パス
- [x] `npx playwright test` — 35 件パス。snapshot 3 件は再生成不要 (bottom padding は初期 scroll 位置の screenshot 範囲外にあるため変化なし)
- [ ] 実機 iPhone Safari でカラム末尾までスクロールし、最下タスクが Home Indicator と被らないことを確認