### PR TITLE
fix(task-manager): 完了/中止タスクをタップしても詳細が開かない問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ docker compose up -d --build --force-recreate
 
 コード変更後はコンテナを再起動して動作を確認する。
 
+**普段は dev サーバーを停止しておく。** port 3000 を占有すると他プロジェクトで使えなくなるため、動作確認が必要なときだけ起動し、確認が終わったら `docker compose down` で停止する。アイドル時・タスク完了後もコンテナを残さない。
+
 ## 3. コミット前テスト
 
 **ユニットテスト**（先に実行）
@@ -31,8 +33,10 @@ source ~/.nvm/nvm.sh && npm run test:unit
 **Playwright テスト**（コンテナ停止が必要。Playwright が自動で再生成するため競合を防ぐ）
 
 ```
-docker compose down && source ~/.nvm/nvm.sh && npx playwright test && docker compose up -d --build --force-recreate
+docker compose down && source ~/.nvm/nvm.sh && npx playwright test
 ```
+
+テスト後はサーバーを停止したままにする（再起動しない）。
 
 ## 4. コミット・プッシュ・PR 作成
 

--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -35,7 +35,7 @@ export function BoardColumn({
   searchQuery: string
   advancedFilter: AdvancedFilter
   sort: SortConfig
-  onSelect: (id: string) => void
+  onSelect: (task: Task) => void
 }) {
   // 完了/中止カラムは初回ページ取得から除外しているため、カラムが viewport に
   // 入ったタイミングで一度だけ fetch する (ページ初期化を軽くする目的)。

--- a/src/components/TaskBoard.tsx
+++ b/src/components/TaskBoard.tsx
@@ -28,7 +28,7 @@ export const TaskBoard = forwardRef<
     searchQuery: string
     advancedFilter: AdvancedFilter
     sort: SortConfig
-    onSelect: (id: string) => void
+    onSelect: (task: Task) => void
   }
 >(function TaskBoard({ tasks, searchQuery, advancedFilter, sort, onSelect }, ref) {
   return (

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -13,7 +13,7 @@ import { useTasksRefresh } from "./TasksRefreshContext"
 //
 // memo: 検索打鍵 / フィルタ・ソート切替 / refresh 後に親で tasks 配列が新しく
 // なるが、要素の参照 (task) が変わらない限り再 render を skip。多数カードの jank 軽減。
-export const TaskItem = memo(function TaskItem({ task, onSelect }: { task: Task; onSelect: (id: string) => void }) {
+export const TaskItem = memo(function TaskItem({ task, onSelect }: { task: Task; onSelect: (task: Task) => void }) {
   const [, startTransition] = useTransition()
   const [optimisticStatus, setOptimisticStatus] = useOptimistic(task.status)
   const selectRef = useRef<HTMLSelectElement>(null)
@@ -31,7 +31,7 @@ export const TaskItem = memo(function TaskItem({ task, onSelect }: { task: Task;
       data-task-id={task.id}
       data-status={status ?? "未着手"}
       className="rounded-lg border border-[var(--border-strong)] bg-[var(--surface)] hover:bg-[var(--surface-2)] hover:border-[var(--border-accent)] card-glow-hover cursor-pointer"
-      onClick={() => onSelect(task.id)}
+      onClick={() => onSelect(task)}
     >
       <div className={`flex items-center gap-2 px-4 ${hasMeta || updateError ? "pt-2 pb-2" : "pt-3 pb-3"}`}>
         {task.icon && (

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -34,6 +34,9 @@ export function TaskManager({
   const [filterSheetOpen, setFilterSheetOpen] = useState(false)
   const [sortSheetOpen, setSortSheetOpen] = useState(false)
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(initialTaskId ?? null)
+  // 完了/中止は BoardColumn 内で lazy fetch されるため、親 tasks に存在しない。
+  // 選択時に Task オブジェクトを直接受け取って fallback として保持する。
+  const [externalSelectedTask, setExternalSelectedTask] = useState<Task | null>(null)
   const [searchQuery, setSearchQuery] = useState("")
   const advancedActive = isAdvancedFilterActive(advancedFilter)
   const sortActive = isSortActive(sort)
@@ -50,8 +53,22 @@ export function TaskManager({
     prevIsPendingRef.current = isPending
   }, [isPending])
 
-  // 選択中タスクは現在の tasks から検索
-  const selectedTask = selectedTaskId ? tasks.find((t) => t.id === selectedTaskId) ?? null : null
+  // 選択中タスクはまず現在の tasks から検索 (refresh 後の最新を反映するため)、
+  // 見つからなければ externalSelectedTask (lazy load 経由で渡された Task) を使う。
+  const selectedTask = selectedTaskId
+    ? tasks.find((t) => t.id === selectedTaskId) ??
+      (externalSelectedTask?.id === selectedTaskId ? externalSelectedTask : null)
+    : null
+
+  function handleSelect(task: Task) {
+    setSelectedTaskId(task.id)
+    setExternalSelectedTask(task)
+  }
+
+  function handleCloseDetail() {
+    setSelectedTaskId(null)
+    setExternalSelectedTask(null)
+  }
 
   // 初回ロード: 画面 (header / toolbar / board の枠) を即時表示してからデータを取得する。
   // 親から tasks が seed されている場合 (テスト等) は fetch をスキップする。
@@ -210,13 +227,13 @@ export function TaskManager({
           searchQuery={searchQuery}
           advancedFilter={advancedFilter}
           sort={sort}
-          onSelect={setSelectedTaskId}
+          onSelect={handleSelect}
         />
       </main>
 
       <TaskCreate tagOptions={tagOptions} />
       {selectedTask && (
-        <TaskDetail task={selectedTask} tagOptions={tagOptions} onClose={() => setSelectedTaskId(null)} />
+        <TaskDetail task={selectedTask} tagOptions={tagOptions} onClose={handleCloseDetail} />
       )}
       <TaskFilterSheet
         open={filterSheetOpen}


### PR DESCRIPTION
## Summary
- 完了 / 中止カラムは `BoardColumn` 内で lazy fetch しており、親 `TaskManager.tasks` には含まれない。`selectedTask` を `tasks.find(t => t.id === selectedTaskId)` で導出していたため、それらのタスクをタップしても `selectedTask` が `null` になり詳細モーダルが開かなかった。
- `onSelect` のシグネチャを `(id: string) => void` → `(task: Task) => void` に変更し、`TaskManager` で fallback の `externalSelectedTask` を保持。親 `tasks` にあれば優先 (refresh 後の最新反映)、無ければ fallback を使う。

## Test plan
- [x] `npm run test:unit` (253 / 253 passed)
- [x] `npx playwright test` (35 / 35 passed)
- [ ] 完了タスクをタップ → 詳細モーダルが開く
- [ ] 中止タスクをタップ → 詳細モーダルが開く
- [ ] 既存のタスク (未着手 / 進行中 / 確認中 / 一時中断) のタップも従来通り動作
- [ ] URL deep link (`?taskId=xxx`) も従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)