### PR TITLE
feat(subtask): タスク詳細からサブタスクを追加・一覧表示できるようにする

### DIFF
--- a/e2e/task-detail.spec.ts
+++ b/e2e/task-detail.spec.ts
@@ -74,3 +74,78 @@ test.describe("タスク詳細ボトムシート", () => {
     await expect(page.locator(TASK_DETAIL)).not.toBeVisible({ timeout: 5_000 })
   })
 })
+
+test.describe("サブタスク", () => {
+  test.describe.configure({ mode: "serial" })
+
+  let context: BrowserContext
+  let page: Page
+
+  const PARENT_TITLE = "【DEV】技術ブログ記事を書く"
+  const CHILD_TITLE = "【DEV】ドラフト作成"
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext({ storageState: AUTH_FILE })
+    page = await context.newPage()
+    await resetAndOpenHome(page)
+  })
+
+  test.afterAll(async () => {
+    await context.close()
+  })
+
+  async function openTaskDetail(title: string) {
+    await page
+      .locator(`${BOARD} ${TASK_ITEM} [data-testid='task-title']`, { hasText: title })
+      .first()
+      .click()
+    await expect(page.locator(TASK_DETAIL)).toBeVisible({ timeout: 5_000 })
+    await expect(page.locator('input[aria-label="タイトル"]')).toHaveValue(title, { timeout: 5_000 })
+  }
+
+  async function closeDetailIfOpen() {
+    const detail = page.locator(TASK_DETAIL)
+    if (await detail.isVisible().catch(() => false)) {
+      await page.locator(TASK_DETAIL_BACKDROP).click({ position: { x: 10, y: 10 } })
+      await detail.waitFor({ state: "hidden", timeout: 5_000 })
+    }
+  }
+
+  test.beforeEach(async () => {
+    await closeDetailIfOpen()
+  })
+
+  test("親タスク詳細にサブタスク一覧が表示される", async () => {
+    await openTaskDetail(PARENT_TITLE)
+    const section = page.locator("[data-testid='subtask-section']")
+    await expect(section).toBeVisible()
+    await expect(
+      section.locator("[data-testid='subtask-item']", { hasText: CHILD_TITLE }),
+    ).toBeVisible()
+  })
+
+  test("サブタスクをタップすると子タスクの詳細に切り替わり、親に戻れる", async () => {
+    await openTaskDetail(PARENT_TITLE)
+    await page.locator("[data-testid='subtask-item']", { hasText: CHILD_TITLE }).click()
+    await expect(page.locator('input[aria-label="タイトル"]')).toHaveValue(CHILD_TITLE, { timeout: 5_000 })
+
+    await page.locator("[data-testid='parent-task-item']", { hasText: PARENT_TITLE }).click()
+    await expect(page.locator('input[aria-label="タイトル"]')).toHaveValue(PARENT_TITLE, { timeout: 5_000 })
+  })
+
+  test("サブタスク追加で新しい子タスクが一覧に出る", async () => {
+    await openTaskDetail(PARENT_TITLE)
+
+    await page.locator("[data-testid='subtask-add-button']").click()
+    await expect(page.getByText("✦ New Subtask")).toBeVisible({ timeout: 5_000 })
+
+    const newTitle = `E2E サブタスク ${Date.now()}`
+    await page.getByPlaceholder(/TASK NAME/).fill(newTitle)
+    await page.getByRole("button", { name: /ADD SUBTASK/i }).click()
+
+    await expect(page.getByText("✦ New Subtask")).not.toBeVisible({ timeout: 5_000 })
+    await expect(
+      page.locator("[data-testid='subtask-item']", { hasText: newTitle }),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -4,7 +4,7 @@ import { updateTag } from "next/cache"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { auth } from "@/auth"
-import { updateTask, createTask, getTaskBlocks, updateTaskBlocks, getTaskComments, createTaskComment, getTasks, getTagOptions } from "@/lib/notion"
+import { updateTask, createTask, getTask, getTaskBlocks, updateTaskBlocks, getTaskComments, createTaskComment, getTasks, getTagOptions } from "@/lib/notion"
 import type { AdvancedFilter, SortConfig, Task, TaskStatus, TaskComment, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 
 function isDevMode() {
@@ -67,6 +67,13 @@ export async function getCompletedTasksAction(): Promise<Task[]> {
 export async function getCancelledTasksAction(): Promise<Task[]> {
   await requireAuth()
   return getTasks({ statuses: ["中止"] })
+}
+
+export async function getTasksByIdsAction(ids: string[]): Promise<Task[]> {
+  await requireAuth()
+  if (ids.length === 0) return []
+  const tasks = await Promise.all(ids.map((id) => getTask(id)))
+  return tasks.filter((t): t is Task => t !== null)
 }
 
 export async function getTaskBlocksAction(id: string): Promise<string> {

--- a/src/components/TaskCreate.tsx
+++ b/src/components/TaskCreate.tsx
@@ -1,86 +1,16 @@
 "use client"
 
-import { useEffect, useState, useRef, useTransition } from "react"
-import { useFormStatus } from "react-dom"
-import { createTaskAction } from "@/app/actions"
-import { buildDue } from "@/lib/due-date"
-import { DueDateTimeInput } from "./DueDateTimeInput"
-import { TagSelector } from "./TagSelector"
-import { useTasksRefresh } from "./TasksRefreshContext"
-import type { TaskStatus, TaskPriority } from "@/types/task"
-
-function SubmitButton() {
-  const { pending } = useFormStatus()
-  return (
-    <button
-      type="submit"
-      disabled={pending}
-      className="font-pixel w-full rounded-lg py-3 text-sm tracking-widest uppercase font-semibold disabled:opacity-40 transition-all"
-      style={{
-        backgroundColor: "var(--accent)",
-        color: "var(--bg)",
-        boxShadow: pending ? "none" : "0 0 8px rgba(220,20,60,0.4)",
-        minHeight: "var(--tap-min)",
-      }}
-    >
-      {pending ? "CREATING..." : "CREATE TASK"}
-    </button>
-  )
-}
+import { useState } from "react"
+import { TaskFormSheet } from "./TaskFormSheet"
 
 export function TaskCreate({ tagOptions }: { tagOptions: string[] }) {
   const [open, setOpen] = useState(false)
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
-  const [dueDate, setDueDate] = useState("")
-  const [dueTime, setDueTime] = useState("")
-  const [, startTransition] = useTransition()
-  const formRef = useRef<HTMLFormElement>(null)
-  const refreshTasks = useTasksRefresh()
-
-  useEffect(() => {
-    if (!open) return
-    const prev = document.body.style.overflow
-    document.body.style.overflow = "hidden"
-    return () => { document.body.style.overflow = prev }
-  }, [open])
-
-  function handleOpen() {
-    setSelectedTags([])
-    setOpen(true)
-  }
-
-  function handleClose() {
-    setOpen(false)
-    formRef.current?.reset()
-    setSelectedTags([])
-    setDueDate("")
-    setDueTime("")
-  }
-
-  async function handleAction(formData: FormData) {
-    const title = (formData.get("title") as string)?.trim()
-    if (!title) return
-    const body = (formData.get("body") as string)?.trim() || undefined
-
-    startTransition(async () => {
-      await createTaskAction({
-        title,
-        status: (formData.get("status") as TaskStatus) || "未着手",
-        priority: (formData.get("priority") as TaskPriority) || undefined,
-        due: buildDue(dueDate, dueTime) ?? undefined,
-        tags: selectedTags.length > 0 ? selectedTags : undefined,
-        body,
-      })
-      handleClose()
-      refreshTasks()
-    })
-  }
 
   return (
     <>
       {/* FAB */}
       <button
-        onClick={handleOpen}
+        onClick={() => setOpen(true)}
         className="fixed bottom-8 right-6 z-10 w-14 h-14 rounded-full flex items-center justify-center text-2xl transition-all active:scale-95"
         style={{
           backgroundColor: "var(--accent)",
@@ -95,87 +25,7 @@ export function TaskCreate({ tagOptions }: { tagOptions: string[] }) {
         </svg>
       </button>
 
-      {/* Bottom sheet */}
-      {open && (
-        <div className="fixed inset-0 z-50 flex flex-col justify-end">
-          <div className="absolute inset-0 bg-black/70" onClick={handleClose} />
-
-          <div
-            className="relative rounded-t-2xl px-4 pt-4 pb-8 safe-bottom max-h-[85svh] overflow-y-auto overscroll-contain"
-            style={{
-              backgroundColor: "var(--surface)",
-              borderTop: "1px solid var(--border-strong)",
-              boxShadow: "0 -8px 40px rgba(0,0,0,0.5)",
-            }}
-          >
-            {/* Handle */}
-            <div className="w-10 h-1 rounded-full mx-auto mb-4" style={{ backgroundColor: "var(--border-strong)" }} />
-
-            <h2 className="font-pixel text-sm text-[var(--accent)] tracking-widest uppercase mb-4 accent-glow-text-sm">
-              ✦ New Task
-            </h2>
-
-            <form ref={formRef} action={handleAction} className="flex flex-col gap-4">
-              <input
-                name="title"
-                type="text"
-                placeholder="TASK NAME (required)"
-                required
-                autoFocus
-                className="field w-full"
-              />
-
-              <textarea
-                name="body"
-                placeholder="BODY (optional)"
-                rows={3}
-                className="field w-full resize-none min-h-[88px]"
-              />
-
-              <div className="grid grid-cols-2 gap-3">
-                <select
-                  name="status"
-                  defaultValue="未着手"
-                  className="field w-full"
-                >
-                  {(["未着手", "進行中", "確認中"] as TaskStatus[]).map((s) => (
-                    <option key={s} value={s}>{s}</option>
-                  ))}
-                </select>
-                <select
-                  name="priority"
-                  defaultValue=""
-                  className="field w-full"
-                >
-                  <option value="">Priority</option>
-                  <option value="high">🚨 High</option>
-                  <option value="medium">⚠️ Med</option>
-                  <option value="low">💤 Low</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="font-pixel block text-xs text-[var(--text-dim)] mb-4 tracking-widest uppercase">期限</label>
-                <DueDateTimeInput
-                  date={dueDate}
-                  time={dueTime}
-                  onChange={(d, t) => {
-                    setDueDate(d)
-                    setDueTime(t)
-                  }}
-                />
-              </div>
-
-              <div>
-                <p className="font-pixel text-xs text-[var(--text-dim)] mb-4 tracking-widest uppercase">タグ</p>
-                <TagSelector options={tagOptions} selected={selectedTags} onChange={setSelectedTags} />
-              </div>
-
-              <SubmitButton />
-            </form>
-          </div>
-        </div>
-      )}
+      <TaskFormSheet open={open} onClose={() => setOpen(false)} tagOptions={tagOptions} />
     </>
   )
 }

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -1,19 +1,75 @@
 "use client"
 
-import { useTransition, useState, useEffect, useRef } from "react"
+import { useTransition, useState, useEffect, useRef, useMemo, type CSSProperties } from "react"
 import type { Task, TaskComment, TaskStatus, TaskPriority } from "@/types/task"
-import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction, getTaskCommentsAction, createTaskCommentAction } from "@/app/actions"
-import { STATUS_OPTIONS, STATUS_STYLES } from "@/constants/styles"
+import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction, getTaskCommentsAction, createTaskCommentAction, getTasksByIdsAction } from "@/app/actions"
+import { STATUS_OPTIONS, STATUS_STYLES, STATUS_ACCENT } from "@/constants/styles"
+import { TaskFormSheet } from "./TaskFormSheet"
 import { MarkdownPreview } from "./MarkdownPreview"
 import { parseDue, buildDue, snapTimeTo5Min, formatDueShort } from "@/lib/due-date"
 import { DueDateTimeInput } from "./DueDateTimeInput"
 import { TagSelector } from "./TagSelector"
 import { useTasksRefresh } from "./TasksRefreshContext"
 
-export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptions: string[]; onClose: () => void }) {
+export function TaskDetail({ task, tagOptions, allTasks = [], onSelectTask = () => {}, onClose }: {
+  task: Task
+  tagOptions: string[]
+  allTasks?: Task[]
+  onSelectTask?: (task: Task) => void
+  onClose: () => void
+}) {
   const [, startTransition] = useTransition()
   const [visible, setVisible] = useState(false)
   const refreshTasks = useTasksRefresh()
+
+  // 子/親タスク解決: in-memory の allTasks から引き、欠落 ID (完了/中止など
+  // lazy fetch 未取得) は getTasksByIdsAction で補完する。
+  const [extraTasks, setExtraTasks] = useState<Record<string, Task>>({})
+  const [subtaskFormOpen, setSubtaskFormOpen] = useState(false)
+
+  const taskById = useMemo(() => {
+    const m = new Map<string, Task>()
+    for (const t of allTasks) m.set(t.id, t)
+    for (const t of Object.values(extraTasks)) m.set(t.id, t)
+    return m
+  }, [allTasks, extraTasks])
+
+  const childIds = useMemo(() => {
+    const s = new Set<string>(task.childTaskIds)
+    for (const t of allTasks) if (t.parentTaskIds.includes(task.id)) s.add(t.id)
+    s.delete(task.id)
+    return [...s]
+  }, [task.id, task.childTaskIds, allTasks])
+
+  const parentIds = task.parentTaskIds
+
+  const childTasks = childIds
+    .map((id) => taskById.get(id))
+    .filter((t): t is Task => t !== undefined)
+  const parentTasks = parentIds
+    .map((id) => taskById.get(id))
+    .filter((t): t is Task => t !== undefined)
+
+  useEffect(() => {
+    const need = [...childIds, ...parentIds].filter((id) => !taskById.has(id))
+    if (need.length === 0) return
+    let cancelled = false
+    try {
+      Promise.resolve(getTasksByIdsAction(need))
+        .then((res) => {
+          if (cancelled || res.length === 0) return
+          setExtraTasks((prev) => {
+            const next = { ...prev }
+            for (const t of res) next[t.id] = t
+            return next
+          })
+        })
+        .catch(() => {})
+    } catch {
+      // action 未提供 (テスト等) — 無視
+    }
+    return () => { cancelled = true }
+  }, [childIds, parentIds, taskById])
 
   const [editTitle, setEditTitle] = useState(task.title)
   const [editStatus, setEditStatus] = useState<TaskStatus>(task.status ?? "未着手")
@@ -403,17 +459,37 @@ export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptio
             </Row>
           )}
 
-          {task.childTaskIds.length > 0 && (
-            <Row label="子タスク">
-              <span className="text-sm text-[var(--text)]">{task.childTaskIds.length}件</span>
+          {parentTasks.length > 0 && (
+            <Row label="親タスク" block>
+              <div className="flex flex-col gap-2">
+                {parentTasks.map((p) => (
+                  <RelatedTaskRow key={p.id} task={p} testid="parent-task-item" onClick={() => onSelectTask(p)} />
+                ))}
+              </div>
             </Row>
           )}
 
-          {task.parentTaskIds.length > 0 && (
-            <Row label="親タスク">
-              <span className="text-sm text-[var(--text)]">{task.parentTaskIds.length}件</span>
+          <div data-testid="subtask-section">
+            <Row label="サブタスク" block>
+              <div className="flex flex-col gap-2">
+                {childTasks.map((c) => (
+                  <RelatedTaskRow key={c.id} task={c} testid="subtask-item" onClick={() => onSelectTask(c)} />
+                ))}
+                {childTasks.length === 0 && (
+                  <span className="text-sm text-[var(--text-faint)]">なし</span>
+                )}
+                <button
+                  type="button"
+                  data-testid="subtask-add-button"
+                  onClick={() => setSubtaskFormOpen(true)}
+                  className="font-pixel flex items-center justify-center gap-2 w-full rounded-lg py-3 text-xs text-[var(--text-dim)] hover:text-[var(--accent)] hover:border-[var(--border-accent)] transition-colors tracking-widest uppercase"
+                  style={{ border: "1px solid var(--border-strong)", minHeight: "var(--tap-min)" }}
+                >
+                  + サブタスク追加
+                </button>
+              </div>
             </Row>
-          )}
+          </div>
         </div>
 
         {/* 本文 */}
@@ -569,7 +645,51 @@ export function TaskDetail({ task, tagOptions, onClose }: { task: Task; tagOptio
           Open in Notion →
         </a>
       </div>
+
+      <TaskFormSheet
+        open={subtaskFormOpen}
+        onClose={() => setSubtaskFormOpen(false)}
+        tagOptions={tagOptions}
+        parentTaskId={task.id}
+        heading="✦ New Subtask"
+        submitLabel="ADD SUBTASK"
+      />
     </div>
+  )
+}
+
+function RelatedTaskRow({
+  task,
+  onClick,
+  testid,
+}: {
+  task: Task
+  onClick: () => void
+  testid: string
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testid}
+      data-task-id={task.id}
+      onClick={onClick}
+      className="flex items-center gap-2 w-full text-left rounded-lg border border-[var(--border-strong)] bg-[var(--surface-2)] px-3 py-2 hover:border-[var(--border-accent)] transition-colors"
+      style={{ minHeight: "var(--tap-min)" }}
+    >
+      {task.icon && (
+        task.icon.type === "emoji" ? (
+          <span aria-hidden="true" className="flex-shrink-0 text-base leading-none">{task.icon.emoji}</span>
+        ) : (
+          <img src={task.icon.url} alt="" className="flex-shrink-0 w-4 h-4 rounded object-cover" />
+        )
+      )}
+      <span className="flex-1 min-w-0 text-sm text-[var(--text)] break-words">{task.title}</span>
+      <span
+        aria-hidden="true"
+        className="status-dot flex-shrink-0"
+        style={{ "--status-color": STATUS_ACCENT[task.status ?? "未着手"] } as CSSProperties}
+      />
+    </button>
   )
 }
 

--- a/src/components/TaskFormSheet.tsx
+++ b/src/components/TaskFormSheet.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { useEffect, useState, useRef, useTransition } from "react"
+import { useFormStatus } from "react-dom"
+import { createTaskAction } from "@/app/actions"
+import { buildDue } from "@/lib/due-date"
+import { DueDateTimeInput } from "./DueDateTimeInput"
+import { TagSelector } from "./TagSelector"
+import { useTasksRefresh } from "./TasksRefreshContext"
+import type { TaskStatus, TaskPriority } from "@/types/task"
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus()
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="font-pixel w-full rounded-lg py-3 text-sm tracking-widest uppercase font-semibold disabled:opacity-40 transition-all"
+      style={{
+        backgroundColor: "var(--accent)",
+        color: "var(--bg)",
+        boxShadow: pending ? "none" : "0 0 8px rgba(220,20,60,0.4)",
+        minHeight: "var(--tap-min)",
+      }}
+    >
+      {pending ? "..." : label}
+    </button>
+  )
+}
+
+export function TaskFormSheet({
+  open,
+  onClose,
+  tagOptions,
+  parentTaskId,
+  heading = "✦ New Task",
+  submitLabel = "CREATE TASK",
+  onCreated,
+}: {
+  open: boolean
+  onClose: () => void
+  tagOptions: string[]
+  parentTaskId?: string
+  heading?: string
+  submitLabel?: string
+  onCreated?: () => void
+}) {
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [dueDate, setDueDate] = useState("")
+  const [dueTime, setDueTime] = useState("")
+  const [, startTransition] = useTransition()
+  const formRef = useRef<HTMLFormElement>(null)
+  const refreshTasks = useTasksRefresh()
+
+  useEffect(() => {
+    if (!open) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => { document.body.style.overflow = prev }
+  }, [open])
+
+  function reset() {
+    formRef.current?.reset()
+    setSelectedTags([])
+    setDueDate("")
+    setDueTime("")
+  }
+
+  function handleClose() {
+    reset()
+    onClose()
+  }
+
+  async function handleAction(formData: FormData) {
+    const title = (formData.get("title") as string)?.trim()
+    if (!title) return
+    const body = (formData.get("body") as string)?.trim() || undefined
+
+    startTransition(async () => {
+      await createTaskAction({
+        title,
+        status: (formData.get("status") as TaskStatus) || "未着手",
+        priority: (formData.get("priority") as TaskPriority) || undefined,
+        due: buildDue(dueDate, dueTime) ?? undefined,
+        tags: selectedTags.length > 0 ? selectedTags : undefined,
+        body,
+        parentTaskId,
+      })
+      handleClose()
+      refreshTasks()
+      onCreated?.()
+    })
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-[60] flex flex-col justify-end">
+      <div className="absolute inset-0 bg-black/70" onClick={handleClose} />
+
+      <div
+        className="relative rounded-t-2xl px-4 pt-4 pb-8 safe-bottom max-h-[85svh] overflow-y-auto overscroll-contain"
+        style={{
+          backgroundColor: "var(--surface)",
+          borderTop: "1px solid var(--border-strong)",
+          boxShadow: "0 -8px 40px rgba(0,0,0,0.5)",
+        }}
+      >
+        {/* Handle */}
+        <div className="w-10 h-1 rounded-full mx-auto mb-4" style={{ backgroundColor: "var(--border-strong)" }} />
+
+        <h2 className="font-pixel text-sm text-[var(--accent)] tracking-widest uppercase mb-4 accent-glow-text-sm">
+          {heading}
+        </h2>
+
+        <form ref={formRef} action={handleAction} className="flex flex-col gap-4">
+          <input
+            name="title"
+            type="text"
+            placeholder="TASK NAME (required)"
+            required
+            autoFocus
+            className="field w-full"
+          />
+
+          <textarea
+            name="body"
+            placeholder="BODY (optional)"
+            rows={3}
+            className="field w-full resize-none min-h-[88px]"
+          />
+
+          <div className="grid grid-cols-2 gap-3">
+            <select
+              name="status"
+              defaultValue="未着手"
+              className="field w-full"
+            >
+              {(["未着手", "進行中", "確認中"] as TaskStatus[]).map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+            <select
+              name="priority"
+              defaultValue=""
+              className="field w-full"
+            >
+              <option value="">Priority</option>
+              <option value="high">🚨 High</option>
+              <option value="medium">⚠️ Med</option>
+              <option value="low">💤 Low</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="font-pixel block text-xs text-[var(--text-dim)] mb-4 tracking-widest uppercase">期限</label>
+            <DueDateTimeInput
+              date={dueDate}
+              time={dueTime}
+              onChange={(d, t) => {
+                setDueDate(d)
+                setDueTime(t)
+              }}
+            />
+          </div>
+
+          <div>
+            <p className="font-pixel text-xs text-[var(--text-dim)] mb-4 tracking-widest uppercase">タグ</p>
+            <TagSelector options={tagOptions} selected={selectedTags} onChange={setSelectedTags} />
+          </div>
+
+          <SubmitButton label={submitLabel} />
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -233,7 +233,14 @@ export function TaskManager({
 
       <TaskCreate tagOptions={tagOptions} />
       {selectedTask && (
-        <TaskDetail task={selectedTask} tagOptions={tagOptions} onClose={handleCloseDetail} />
+        <TaskDetail
+          key={selectedTask.id}
+          task={selectedTask}
+          tagOptions={tagOptions}
+          allTasks={tasks}
+          onSelectTask={handleSelect}
+          onClose={handleCloseDetail}
+        />
       )}
       <TaskFilterSheet
         open={filterSheetOpen}

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { TaskDetail } from "@/components/TaskDetail"
-import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction } from "@/app/actions"
+import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction, getTasksByIdsAction } from "@/app/actions"
 import type { Task } from "@/types/task"
 
 const TAG_OPTIONS = ["Network", "Blog", "Operation", "Finance", "Tech", "買い物🛍️"]
@@ -10,6 +10,7 @@ vi.mock("@/app/actions", () => ({
   updateTaskAction: vi.fn().mockResolvedValue(undefined),
   getTaskBlocksAction: vi.fn().mockResolvedValue(""),
   updateTaskBlocksAction: vi.fn().mockResolvedValue(undefined),
+  getTasksByIdsAction: vi.fn().mockResolvedValue([]),
 }))
 
 // requestAnimationFrame を同期実行してアニメーション初期化を完了させる
@@ -22,6 +23,7 @@ beforeEach(() => {
   vi.mocked(updateTaskAction).mockResolvedValue(undefined)
   vi.mocked(getTaskBlocksAction).mockResolvedValue("")
   vi.mocked(updateTaskBlocksAction).mockResolvedValue(undefined)
+  vi.mocked(getTasksByIdsAction).mockResolvedValue([])
 })
 
 afterEach(() => {
@@ -167,14 +169,15 @@ describe("TaskDetail レンダリング", () => {
     expect(link.closest("a")).toHaveAttribute("href", "https://example.com")
   })
 
-  it("子タスク数を表示する", () => {
-    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ childTaskIds: ["c1", "c2"] })} onClose={() => {}} />)
-    expect(screen.getByText("2件")).toBeInTheDocument()
+  it("サブタスクセクションと追加ボタンを常に表示する", () => {
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
+    expect(screen.getByTestId("subtask-section")).toBeInTheDocument()
+    expect(screen.getByTestId("subtask-add-button")).toBeInTheDocument()
   })
 
-  it("親タスク数を表示する", () => {
-    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ parentTaskIds: ["p1"] })} onClose={() => {}} />)
-    expect(screen.getByText("1件")).toBeInTheDocument()
+  it("子タスクが無いとき「なし」を表示する", () => {
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
+    expect(screen.getByText("なし")).toBeInTheDocument()
   })
 
   it("Notion リンクが正しい href を持つ", () => {
@@ -546,5 +549,100 @@ describe("TaskDetail スワイプ動作", () => {
     fireEvent.touchEnd(panel, { changedTouches: [{ clientY: 50 }] })
 
     expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+describe("TaskDetail サブタスク", () => {
+  it("allTasks の reverse-lookup で子タスクを一覧表示する", () => {
+    const parent = makeTask({ id: "p", title: "親タスク" })
+    const child = makeTask({ id: "c", title: "子タスクA", parentTaskIds: ["p"] })
+
+    render(
+      <TaskDetail
+        tagOptions={TAG_OPTIONS}
+        task={parent}
+        allTasks={[parent, child]}
+        onClose={() => {}}
+      />,
+    )
+
+    const items = screen.getAllByTestId("subtask-item")
+    expect(items).toHaveLength(1)
+    expect(screen.getByText("子タスクA")).toBeInTheDocument()
+  })
+
+  it("childTaskIds に有り reverse-lookup にも有る子は重複表示しない", () => {
+    const parent = makeTask({ id: "p", title: "親", childTaskIds: ["c"] })
+    const child = makeTask({ id: "c", title: "子タスクA", parentTaskIds: ["p"] })
+
+    render(
+      <TaskDetail tagOptions={TAG_OPTIONS} task={parent} allTasks={[parent, child]} onClose={() => {}} />,
+    )
+
+    expect(screen.getAllByTestId("subtask-item")).toHaveLength(1)
+  })
+
+  it("子タスク行タップで onSelectTask がその子で呼ばれる", () => {
+    const parent = makeTask({ id: "p", title: "親" })
+    const child = makeTask({ id: "c", title: "子タスクA", parentTaskIds: ["p"] })
+    const onSelectTask = vi.fn()
+
+    render(
+      <TaskDetail
+        tagOptions={TAG_OPTIONS}
+        task={parent}
+        allTasks={[parent, child]}
+        onSelectTask={onSelectTask}
+        onClose={() => {}}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId("subtask-item"))
+    expect(onSelectTask).toHaveBeenCalledWith(child)
+  })
+
+  it("親タスク行タップで onSelectTask がその親で呼ばれる", () => {
+    const parent = makeTask({ id: "p", title: "親タスク" })
+    const child = makeTask({ id: "c", title: "子", parentTaskIds: ["p"] })
+    const onSelectTask = vi.fn()
+
+    render(
+      <TaskDetail
+        tagOptions={TAG_OPTIONS}
+        task={child}
+        allTasks={[parent, child]}
+        onSelectTask={onSelectTask}
+        onClose={() => {}}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId("parent-task-item"))
+    expect(onSelectTask).toHaveBeenCalledWith(parent)
+  })
+
+  it("allTasks に無い子 ID は getTasksByIdsAction で補完表示する", async () => {
+    const fetched = makeTask({ id: "remote-c", title: "完了済み子タスク", status: "完了" })
+    vi.mocked(getTasksByIdsAction).mockResolvedValueOnce([fetched])
+
+    render(
+      <TaskDetail
+        tagOptions={TAG_OPTIONS}
+        task={makeTask({ id: "p", childTaskIds: ["remote-c"] })}
+        allTasks={[]}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(await screen.findByText("完了済み子タスク")).toBeInTheDocument()
+    expect(vi.mocked(getTasksByIdsAction)).toHaveBeenCalledWith(["remote-c"])
+  })
+
+  it("サブタスク追加ボタンで子タスク作成フォームが開く", () => {
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
+
+    expect(screen.queryByText("✦ New Subtask")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId("subtask-add-button"))
+    expect(screen.getByText("✦ New Subtask")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /ADD SUBTASK/i })).toBeInTheDocument()
   })
 })

--- a/src/components/__tests__/TaskFormSheet.test.tsx
+++ b/src/components/__tests__/TaskFormSheet.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { TaskFormSheet } from "@/components/TaskFormSheet"
+
+const TAG_OPTIONS = ["Network", "Blog", "Tech"]
+
+vi.mock("@/app/actions", () => ({
+  createTaskAction: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("react-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-dom")>()
+  return {
+    ...actual,
+    useFormStatus: vi.fn().mockReturnValue({ pending: false }),
+  }
+})
+
+describe("TaskFormSheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("open=false のとき何もレンダリングしない", () => {
+    const { container } = render(
+      <TaskFormSheet open={false} onClose={() => {}} tagOptions={TAG_OPTIONS} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("既定の見出しと送信ラベルを表示する", () => {
+    render(<TaskFormSheet open onClose={() => {}} tagOptions={TAG_OPTIONS} />)
+    expect(screen.getByText("✦ New Task")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /CREATE TASK/i })).toBeInTheDocument()
+  })
+
+  it("heading / submitLabel を上書きできる", () => {
+    render(
+      <TaskFormSheet
+        open
+        onClose={() => {}}
+        tagOptions={TAG_OPTIONS}
+        heading="✦ New Subtask"
+        submitLabel="ADD SUBTASK"
+      />,
+    )
+    expect(screen.getByText("✦ New Subtask")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /ADD SUBTASK/i })).toBeInTheDocument()
+  })
+
+  it("parentTaskId 指定時は createTaskAction に parentTaskId を渡す", async () => {
+    const { createTaskAction } = await import("@/app/actions")
+    const mock = vi.mocked(createTaskAction)
+
+    render(
+      <TaskFormSheet open onClose={() => {}} tagOptions={TAG_OPTIONS} parentTaskId="parent-1" />,
+    )
+
+    const input = screen.getByPlaceholderText(/TASK NAME/)
+    fireEvent.change(input, { target: { value: "子タスク" } })
+    fireEvent.submit(input.closest("form") as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "子タスク", parentTaskId: "parent-1" }),
+      )
+    })
+  })
+
+  it("parentTaskId 未指定なら parentTaskId は undefined", async () => {
+    const { createTaskAction } = await import("@/app/actions")
+    const mock = vi.mocked(createTaskAction)
+
+    render(<TaskFormSheet open onClose={() => {}} tagOptions={TAG_OPTIONS} />)
+
+    const input = screen.getByPlaceholderText(/TASK NAME/)
+    fireEvent.change(input, { target: { value: "通常タスク" } })
+    fireEvent.submit(input.closest("form") as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "通常タスク", parentTaskId: undefined }),
+      )
+    })
+  })
+
+  it("送信成功後に onClose が呼ばれる", async () => {
+    const onClose = vi.fn()
+    render(<TaskFormSheet open onClose={onClose} tagOptions={TAG_OPTIONS} />)
+
+    const input = screen.getByPlaceholderText(/TASK NAME/)
+    fireEvent.change(input, { target: { value: "タスクX" } })
+    fireEvent.submit(input.closest("form") as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  it("タイトル空では createTaskAction を呼ばない", async () => {
+    const { createTaskAction } = await import("@/app/actions")
+    const mock = vi.mocked(createTaskAction)
+
+    render(<TaskFormSheet open onClose={() => {}} tagOptions={TAG_OPTIONS} />)
+    const input = screen.getByPlaceholderText(/TASK NAME/)
+    fireEvent.submit(input.closest("form") as HTMLFormElement)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(mock).not.toHaveBeenCalled()
+  })
+
+  it("バックドロップクリックで onClose が呼ばれる", () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <TaskFormSheet open onClose={onClose} tagOptions={TAG_OPTIONS} />,
+    )
+    const backdrop = container.querySelector('[class*="bg-black"]') as HTMLElement
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/lib/__tests__/mock-tasks.test.ts
+++ b/src/lib/__tests__/mock-tasks.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { resetMockTasks, createMockTask, getMockTask } from "@/lib/mock-tasks"
+
+describe("createMockTask の親子リレーション", () => {
+  beforeEach(() => {
+    resetMockTasks()
+  })
+
+  it("parentTaskId 指定時に新タスクの parentTaskIds に親が入る", () => {
+    const child = createMockTask({ title: "子", parentTaskId: "mock-2" })
+    expect(child.parentTaskIds).toEqual(["mock-2"])
+  })
+
+  it("parentTaskId 指定時に親タスクの childTaskIds に新 ID が追加される", () => {
+    const child = createMockTask({ title: "子", parentTaskId: "mock-2" })
+    const parent = getMockTask("mock-2")
+    expect(parent?.childTaskIds).toContain(child.id)
+  })
+
+  it("parentTaskId 未指定では既存タスクの childTaskIds を変更しない", () => {
+    const before = [...(getMockTask("mock-2")?.childTaskIds ?? [])]
+    createMockTask({ title: "無関係タスク" })
+    expect(getMockTask("mock-2")?.childTaskIds).toEqual(before)
+  })
+
+  it("存在しない親 ID を指定しても例外を投げない", () => {
+    expect(() => createMockTask({ title: "孤児", parentTaskId: "does-not-exist" })).not.toThrow()
+  })
+})

--- a/src/lib/mock-tasks.ts
+++ b/src/lib/mock-tasks.ts
@@ -290,6 +290,14 @@ export function createMockTask(input: CreateTaskInput): Task {
     lastEditedTime: ts,
   }
   store.push(task)
+  // Notion のシンクド・リレーション挙動を模倣: 子の親を設定したら
+  // 親側の childTaskIds にも反映する。
+  if (input.parentTaskId) {
+    const parent = store.find((t) => t.id === input.parentTaskId)
+    if (parent && !parent.childTaskIds.includes(task.id)) {
+      parent.childTaskIds = [...parent.childTaskIds, task.id]
+    }
+  }
   if (input.body?.trim()) mockBlockStore.set(task.id, input.body)
   return task
 }


### PR DESCRIPTION
## 概要

タスク詳細画面からサブタスク（子タスク）を追加でき、子/親タスクを一覧表示してタップで相互に行き来できるようにした。

## 変更

- **TaskDetail**: 子/親の「N件」表示を一覧 UI に置換。子タスク行タップで詳細へドリルダウン、親タスク行で戻れる。「+ サブタスク追加」ボタンを追加
- **TaskFormSheet（新規）**: 作成フォーム/ボトムシートを共通化。FAB（通常作成）とサブタスク追加で再利用（`parentTaskId` / `heading` / `submitLabel`）
- **TaskManager**: `allTasks` / `onSelectTask` を TaskDetail に渡し、`key={selectedTask.id}` でドリルダウン時に再マウント
- **getTasksByIdsAction**: in-memory に無い完了/中止の子タスクを補完取得
- **createMockTask**: `parentTaskId` 指定時に親の `childTaskIds` も更新（dev/e2e 反映）。reverse-lookup 併用で Notion 同期設定に非依存

## テスト

- ユニット: 全パス（新規 `TaskFormSheet.test` / `mock-tasks.test`、更新 `TaskDetail.test`）
- e2e: 全パス（サブタスク一覧/遷移/追加シナリオを iPhone15・Desktop で追加、スナップショット視覚回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)