### PR TITLE
feat(board): サブタスクをタスク一覧で親タスクの直下にネスト表示する

### DIFF
--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -5,6 +5,7 @@ import type { AdvancedFilter, SortConfig, Task, TaskStatus } from "@/types/task"
 import { TaskItem } from "./TaskItem"
 import { applyAdvancedFilter } from "@/constants/filters"
 import { applySort } from "@/lib/task-sort"
+import { buildNestedOrder } from "@/lib/task-tree"
 import { STATUS_ACCENT } from "@/constants/styles"
 import { getCompletedTasksAction, getCancelledTasksAction } from "@/app/actions"
 
@@ -110,6 +111,10 @@ export function BoardColumn({
     })
   }, [isLazyStatus, propsHasLazy, propLazyTasks, lazyTasks, tasks, statuses, advancedFilter, q, sort])
 
+  // サブタスクを親タスクの直下にインデント表示するため、列を木構造順に並べ替える。
+  // 親が同じ列に居なければ子はルートとして残るので、一覧から消えることはない。
+  const nested = useMemo(() => buildNestedOrder(filtered), [filtered])
+
   const accent = STATUS_ACCENT[accentStatus]
   const isLazyPending = isLazyStatus && !propsHasLazy && lazyTasks === null
   const showLazyLoading = isLazyPending && !hasLoadError
@@ -124,10 +129,10 @@ export function BoardColumn({
   useEffect(() => {
     if (!isLazyStatus) return
     setDisplayCount(INCREMENTAL_INITIAL)
-  }, [isLazyStatus, filtered])
+  }, [isLazyStatus, nested])
 
-  const visible = isLazyStatus ? filtered.slice(0, displayCount) : filtered
-  const hasMore = isLazyStatus && displayCount < filtered.length
+  const visible = isLazyStatus ? nested.slice(0, displayCount) : nested
+  const hasMore = isLazyStatus && displayCount < nested.length
 
   // 末尾 sentinel が見えたら次の chunk をロード。スクロール親 (overflow-y-auto) を
   // root にする。rootMargin: 200px で下端到達前に先読みして体感を滑らかに。
@@ -188,9 +193,10 @@ export function BoardColumn({
           </p>
         ) : (
           <ul className="flex flex-col gap-2">
-            {visible.map((task) => (
+            {visible.map(({ task, depth }) => (
               <li
                 key={task.id}
+                data-subtask-depth={depth}
                 // content-visibility: auto は viewport 外要素の paint/layout を skip して
                 // 大量カード時のスクロール jank を抑える。ただし off-screen 要素の innerText が
                 // 取れなくなる副作用があり、e2e flaky を生んだため、件数が膨らみがちな
@@ -201,7 +207,18 @@ export function BoardColumn({
                     : undefined
                 }
               >
-                <TaskItem task={task} onSelect={onSelect} />
+                {depth > 0 ? (
+                  // サブタスク: 親の下に 16px インデント + 左ガイド線で階層を示す
+                  // (16px / pl-3=12px は 4px グリッド準拠)。
+                  <div
+                    className="border-l border-[var(--border-strong)] pl-3"
+                    style={{ marginLeft: depth * 16 }}
+                  >
+                    <TaskItem task={task} onSelect={onSelect} />
+                  </div>
+                ) : (
+                  <TaskItem task={task} onSelect={onSelect} />
+                )}
               </li>
             ))}
             {hasMore && (

--- a/src/lib/__tests__/task-tree.test.ts
+++ b/src/lib/__tests__/task-tree.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest"
+import { buildNestedOrder } from "@/lib/task-tree"
+import type { Task } from "@/types/task"
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: "t1",
+    url: "https://notion.so/t1",
+    title: "task",
+    icon: null,
+    status: "未着手",
+    priority: null,
+    due: null,
+    tags: [],
+    assignees: [],
+    source: null,
+    sourceUrl: null,
+    parentTaskIds: [],
+    childTaskIds: [],
+    prevTaskIds: [],
+    nextTaskIds: [],
+    createdTime: "2024-01-01T00:00:00.000Z",
+    lastEditedTime: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("buildNestedOrder", () => {
+  it("親の直後に子を depth+1 で並べる", () => {
+    const parent = makeTask({ id: "p" })
+    const child = makeTask({ id: "c", parentTaskIds: ["p"] })
+    const result = buildNestedOrder([parent, child])
+    expect(result.map((n) => [n.task.id, n.depth])).toEqual([
+      ["p", 0],
+      ["c", 1],
+    ])
+  })
+
+  it("子が親より前に来ても親の下にまとめる", () => {
+    const child = makeTask({ id: "c", parentTaskIds: ["p"] })
+    const parent = makeTask({ id: "p" })
+    const result = buildNestedOrder([child, parent])
+    expect(result.map((n) => n.task.id)).toEqual(["p", "c"])
+  })
+
+  it("親が同じ列に居なければ子はルート (depth 0) のまま残す", () => {
+    const child = makeTask({ id: "c", parentTaskIds: ["missing"] })
+    const result = buildNestedOrder([child])
+    expect(result).toEqual([{ task: child, depth: 0 }])
+  })
+
+  it("孫まで再帰的にネストする", () => {
+    const p = makeTask({ id: "p" })
+    const c = makeTask({ id: "c", parentTaskIds: ["p"] })
+    const g = makeTask({ id: "g", parentTaskIds: ["c"] })
+    const result = buildNestedOrder([p, c, g])
+    expect(result.map((n) => [n.task.id, n.depth])).toEqual([
+      ["p", 0],
+      ["c", 1],
+      ["g", 2],
+    ])
+  })
+
+  it("兄弟は入力順を維持する", () => {
+    const p = makeTask({ id: "p" })
+    const c1 = makeTask({ id: "c1", parentTaskIds: ["p"] })
+    const c2 = makeTask({ id: "c2", parentTaskIds: ["p"] })
+    const result = buildNestedOrder([p, c1, c2])
+    expect(result.map((n) => n.task.id)).toEqual(["p", "c1", "c2"])
+  })
+
+  it("循環参照でも全タスクを 1 度ずつ返す", () => {
+    const a = makeTask({ id: "a", parentTaskIds: ["b"] })
+    const b = makeTask({ id: "b", parentTaskIds: ["a"] })
+    const result = buildNestedOrder([a, b])
+    expect(result).toHaveLength(2)
+    expect(new Set(result.map((n) => n.task.id))).toEqual(new Set(["a", "b"]))
+  })
+
+  it("自己参照は無視する", () => {
+    const a = makeTask({ id: "a", parentTaskIds: ["a"] })
+    const result = buildNestedOrder([a])
+    expect(result).toEqual([{ task: a, depth: 0 }])
+  })
+})

--- a/src/lib/task-tree.ts
+++ b/src/lib/task-tree.ts
@@ -1,0 +1,51 @@
+import type { Task } from "@/types/task"
+
+export type NestedTaskNode = { task: Task; depth: number }
+
+// カラム内のタスク列 (フィルタ/ソート済み) を、サブタスクが親タスクの直下に
+// インデント表示されるよう並べ替える。
+//
+// - 親が「同じカラムの可視リストに存在する」場合のみネストする。親が別カラム
+//   (別ステータス) や、フィルタ・検索で除外されている場合、その子はルートとして
+//   そのまま表示する (= タスクが一覧から消えない)。
+// - ルートの並び順、および同じ親を持つ兄弟の並び順は、入力 `tasks` の順序
+//   (= applySort の結果) をそのまま維持する。
+// - 循環参照や、入力に出現しない親 ID は安全に無視する。
+export function buildNestedOrder(tasks: Task[]): NestedTaskNode[] {
+  const byId = new Map<string, Task>()
+  tasks.forEach((t) => byId.set(t.id, t))
+
+  // 各タスクの「このカラム内に存在する親」を 1 つ決める。
+  const parentOf = new Map<string, string>()
+  for (const t of tasks) {
+    const p = t.parentTaskIds.find((pid) => pid !== t.id && byId.has(pid))
+    if (p) parentOf.set(t.id, p)
+  }
+
+  const childrenOf = new Map<string, Task[]>()
+  for (const t of tasks) {
+    const p = parentOf.get(t.id)
+    if (p === undefined) continue
+    if (!childrenOf.has(p)) childrenOf.set(p, [])
+    childrenOf.get(p)!.push(t)
+  }
+
+  const out: NestedTaskNode[] = []
+  const visited = new Set<string>()
+
+  function walk(task: Task, depth: number) {
+    if (visited.has(task.id)) return
+    visited.add(task.id)
+    out.push({ task, depth })
+    for (const c of childrenOf.get(task.id) ?? []) walk(c, depth + 1)
+  }
+
+  for (const t of tasks) {
+    if (parentOf.has(t.id)) continue // 子は親側から辿る
+    walk(t, 0)
+  }
+  // 循環で root から辿れなかったタスクの取りこぼし防止。
+  for (const t of tasks) if (!visited.has(t.id)) walk(t, 0)
+
+  return out
+}


### PR DESCRIPTION
## 背景

「サブタスクもタスク一覧に表示したい」という要望。

調査の結果、サブタスクは技術的には通常タスクと同じステータス列に出ているが、
新規サブタスクは優先度・期限が未設定のため `applySort` で列の末尾に沈み、
親タスクと離れた位置に表示される。長い列では事実上「一覧に出ていない」
ように見えていた。

## 変更

- `buildNestedOrder` を追加し、列内のタスクを木構造順に並べ替え
- サブタスクを親カードの**直下に 16px インデント + 左ガイド線**で表示
- 親が同じ列に居ない場合 (別ステータス / フィルタ除外) は子をルートとして
  そのまま残すため、タスクが一覧から消えることはない
- 完了/中止列の incremental render はネスト後のリストに対して動作

## テスト

- ユニット: `buildNestedOrder` のテスト 7 ケース追加 / 全 278 件パス
- Playwright: 全 41 件パス (視覚回帰・既存サブタスク E2E 含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)