### PR TITLE
feat(loading): タスク一覧のローディング表示をサイバー・イコライザーに置き換える

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -222,6 +222,17 @@ body::before {
   100% { background-position: 100% 0; }
 }
 
+@keyframes equalizer-bar {
+  0%, 100% {
+    transform: scaleY(0.2);
+    box-shadow: 0 0 4px rgba(220, 20, 60, 0.35);
+  }
+  50% {
+    transform: scaleY(1);
+    box-shadow: 0 0 6px var(--accent), 0 0 12px rgba(220, 20, 60, 0.45);
+  }
+}
+
 @layer utilities {
   .animate-dot-pulse {
     animation: dot-pulse 1.8s ease-in-out infinite;
@@ -234,6 +245,15 @@ body::before {
     background: linear-gradient(90deg, var(--accent) 0%, #ff6688 40%, #ffffff 50%, #ff6688 60%, var(--accent) 100%);
     background-size: 200% 100%;
     animation: shimmer-bar 1.2s linear infinite;
+  }
+  /* イコライザー型ローダー (CyberLoader 用): 縦バーが scaleY で脈動 */
+  .equalizer-bar {
+    display: inline-block;
+    background-color: var(--accent);
+    transform-origin: bottom;
+    transform: scaleY(0.2);
+    animation: equalizer-bar 0.9s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    border-radius: 1px;
   }
 }
 

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,3 +1,5 @@
+import { CyberLoader } from "@/components/CyberLoader"
+
 export default function Loading() {
   return (
     <div className="flex flex-col h-full">
@@ -8,7 +10,9 @@ export default function Loading() {
         </div>
       </header>
 
-      <div className="h-0.5 bg-[var(--accent)] animate-pulse w-2/3" style={{ boxShadow: "0 0 6px rgba(220,20,60,0.45)" }} />
+      <div className="flex justify-center items-center h-8 bg-[var(--bg)] border-b border-[var(--border)]">
+        <CyberLoader size="sm" />
+      </div>
 
       <div className="bg-[var(--bg)] border-b border-[var(--border)] px-4 py-3 flex items-center gap-2">
         <div className="flex-1 h-9 bg-[var(--surface)] rounded-lg animate-pulse" />

--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -8,6 +8,7 @@ import { applySort } from "@/lib/task-sort"
 import { buildNestedOrder } from "@/lib/task-tree"
 import { STATUS_ACCENT } from "@/constants/styles"
 import { getCompletedTasksAction, getCancelledTasksAction } from "@/app/actions"
+import { CyberLoader } from "./CyberLoader"
 
 // 完了/中止カラムは件数が膨らみがち。全件を一気に DOM 投入すると React の
 // reconciliation と paint が重くなりスクロール jank の原因になるため、
@@ -180,9 +181,12 @@ export function BoardColumn({
 
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overscroll-contain px-4 pt-4 pb-11">
         {showLazyLoading ? (
-          <p className="font-pixel text-center text-[var(--text-faint)] text-[11px] py-6 tracking-widest">
-            — LOADING —
-          </p>
+          <div
+            data-testid="board-column-loader"
+            className="flex justify-center py-8"
+          >
+            <CyberLoader />
+          </div>
         ) : showLazyError ? (
           <p className="font-pixel text-center text-[var(--status-cancel)] text-[11px] py-6 tracking-widest">
             — LOAD FAILED —

--- a/src/components/CyberLoader.tsx
+++ b/src/components/CyberLoader.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+export function CyberLoader({
+  size = "md",
+  label = "読み込み中",
+}: {
+  size?: "md" | "sm"
+  label?: string
+}) {
+  const barH = size === "sm" ? 20 : 32
+  const delays = [0, 180, 90, 240, 60]
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+      data-testid="cyber-loader"
+      className="inline-flex items-end gap-1"
+      style={{ height: barH }}
+    >
+      {delays.map((d, i) => (
+        <span
+          key={i}
+          aria-hidden="true"
+          className="equalizer-bar"
+          style={{ animationDelay: `${d}ms`, height: barH, width: 4 }}
+        />
+      ))}
+      <span className="sr-only">{label}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- 完了/中止カラムの lazy fetch 中に表示されていた `— LOADING —` テキストを、5 本の縦バーが crimson の発光と共に不均等に脈動する **イコライザー型 `CyberLoader`** に差し替え。
- 初回ボード描画 (`src/app/loading.tsx`) の装飾シマー線も同じ `CyberLoader`（sm サイズ）に差し替え、初期ロード〜lazy fetch〜のトーンを揃えた。
- 新規 `@keyframes equalizer-bar` と `.equalizer-bar` ユーティリティを追加。既存の `dot-pulse` / `spin-cyber` / `shimmer-bar` と同じ命名規則・配置に揃えた。
- すべてのサイズ・余白は 4px グリッド準拠（バー幅 4 / 間隔 4 / 高さ 32 or 20 / `py-8`）。`border-radius: 1px` のみ装飾的細線扱い。
- アクセシビリティ: `role="status"` + `aria-live="polite"` + `sr-only` ラベル「読み込み中」で、視覚的にテキストは出さずにスクリーンリーダーには通知する。

## Notes

- 既存テストで `LOADING` 文字列を assert している箇所はゼロ (`grep -rn LOADING` で確認済み)。
- ユニットテスト 278 件すべてパス。
- Playwright のスナップショット 3 件 (`board: 初期表示` / `「進行中」へスクロール` / `detail sheet`) は **クリーンな main でも同様に失敗** する既存フレーク。`fullPage: true` が iPhone 15 ビューポート (393×659) ではなく横スクロール全幅 (1538×659) を撮ってしまう問題で、本変更とは無関係。

## Test plan

- [x] `npm run test:unit` (278 passed)
- [x] `npx playwright test` (snapshot 3 件以外は全パス、snapshot は main でも fail する既存フレーク)
- [ ] 視覚確認: `docker compose up -d --build --force-recreate` で起動し、`完了` カラムまでスクロールしてイコライザー表示を確認 → 確認後 `docker compose down`

🤖 Generated with [Claude Code](https://claude.com/claude-code)