### PR TITLE
fix(due-date): タスク登録/編集の日付をクリアできるようにする

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -165,6 +165,25 @@ body::before {
   .icon-btn:active   { transform: scale(0.95); }
   .icon-btn:disabled { opacity: 0.4; }
 
+  /* TaskDetail など密度優先の場面で使う 36×36 のコンパクトアイコンボタン。
+     WCAG 44px は満たさないが .field-sm (36px) と高さを揃えるために許容。 */
+  .icon-btn-sm {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    border: 1px solid var(--border-strong);
+    background-color: var(--surface);
+    color: var(--accent);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: border-color 0.2s, transform 0.1s;
+    flex-shrink: 0;
+  }
+  .icon-btn-sm:hover    { border-color: var(--accent); }
+  .icon-btn-sm:active   { transform: scale(0.95); }
+  .icon-btn-sm:disabled { opacity: 0.4; }
+
   /* TaskItem 用 hover グロー */
   .card-glow-hover { transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s; }
   .card-glow-hover:hover { box-shadow: var(--elev-card-hover); }

--- a/src/components/DueDateTimeInput.tsx
+++ b/src/components/DueDateTimeInput.tsx
@@ -27,6 +27,11 @@ export function DueDateTimeInput({
     size === "compact" ? "px-3" : "px-4"
   }`
 
+  // モバイル (iOS Safari の wheel picker など) ではネイティブ <input type="date">
+  // から値を空に戻す手段が露出していないため、明示的なクリアボタンを置く。
+  // date が無い時は同時に time も無効になるので表示しない。
+  const clearBtnClass = size === "compact" ? "icon-btn-sm" : "icon-btn"
+
   return (
     <div className="flex gap-2 items-center">
       <div className="relative flex-1 min-w-0">
@@ -55,6 +60,31 @@ export function DueDateTimeInput({
         />
         {!time && <span className={placeholderClass}>時刻</span>}
       </div>
+      {date && (
+        <button
+          type="button"
+          onClick={() => onChange("", "")}
+          aria-label="期限をクリア"
+          data-testid="due-clear-button"
+          className={clearBtnClass}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -311,6 +311,19 @@ describe("TaskDetail フィールド変更", () => {
     expect(screen.getByLabelText("期限の時刻")).toBeDisabled()
   })
 
+  it("クリアボタン押下で due: null が送られる (モバイル native picker の代替)", async () => {
+    const mock = vi.mocked(updateTaskAction)
+    mock.mockClear()
+
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", due: "2026-04-30T18:00:00.000+09:00" })} onClose={() => {}} />)
+    fireEvent.click(screen.getByRole("button", { name: "期限をクリア" }))
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith("t1", { due: null })
+    })
+    expect(screen.queryByRole("button", { name: "期限をクリア" })).not.toBeInTheDocument()
+  })
+
   it("タイトル blur で updateTaskAction が呼ばれる", async () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()


### PR DESCRIPTION
## Summary

- モバイル (iOS Safari の wheel picker など) ではネイティブ `<input type="date">` から値を空に戻す手段が露出していないため、一度入れた期限を消せない問題を修正。
- `DueDateTimeInput` に **「期限をクリア」ボタン** (×) を追加。日付が入っているときだけ表示され、押下で日付・時刻の両方を空にし `due: null` を保存する。
- 共通コンポーネントへの 1 箇所修正で、`TaskFormSheet` (新規作成) と `TaskDetail` (編集) の両方が直る。
- `TaskDetail` の compact 表示用に `.icon-btn-sm` (36×36) ユーティリティを globals.css に追加。

## Test plan

- [x] `npm run test:unit` (278 → 279 passed、クリアボタン経由のテストを 1 件追加)
- [x] `npx playwright test` (snapshot 3 件以外は全パス、snapshot は main でも fail する既存フレーク = 前 PR で確認済み)
- [ ] 視覚確認: 新規作成シート/詳細シート両方で、日付入力後にクリアボタンが出る → 押下で日付・時刻が空に戻ることを確認

## Notes

- ロジック層 (`buildDue` → `updateTask` → Notion `{ date: null }`) は元から正しく、JSDOM 上の既存ユニットテスト (`TaskDetail.test.tsx:300`) もグリーン。問題は **モバイルのネイティブ UI がクリア手段を提供していない** こと。
- ボタンは `type="button"` 明示で `<form>` 配下でも submit 発火しない。
- 4px グリッド準拠 (`.icon-btn-sm` = 9×4)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)