### PR TITLE
fix(due-date): クリアボタンを「時刻のみ」を消す挙動に変更する

### DIFF
--- a/src/components/DueDateTimeInput.tsx
+++ b/src/components/DueDateTimeInput.tsx
@@ -27,9 +27,10 @@ export function DueDateTimeInput({
     size === "compact" ? "px-3" : "px-4"
   }`
 
-  // モバイル (iOS Safari の wheel picker など) ではネイティブ <input type="date">
-  // から値を空に戻す手段が露出していないため、明示的なクリアボタンを置く。
-  // date が無い時は同時に time も無効になるので表示しない。
+  // モバイル (iOS Safari の wheel picker など) では <input type="time"> から値を
+  // 空に戻す手段が露出していないため、時刻のみを消す明示的なクリアボタンを置く。
+  // 日付はそのまま残す (日付なしの時刻は意味を持たない / 「期限なし」にしたい場合は
+  // 日付側を変更する)。
   const clearBtnClass = size === "compact" ? "icon-btn-sm" : "icon-btn"
 
   return (
@@ -60,12 +61,12 @@ export function DueDateTimeInput({
         />
         {!time && <span className={placeholderClass}>時刻</span>}
       </div>
-      {date && (
+      {time && (
         <button
           type="button"
-          onClick={() => onChange("", "")}
-          aria-label="期限をクリア"
-          data-testid="due-clear-button"
+          onClick={() => onChange(date, "")}
+          aria-label="時刻をクリア"
+          data-testid="due-time-clear-button"
           className={clearBtnClass}
         >
           <svg

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -311,17 +311,18 @@ describe("TaskDetail フィールド変更", () => {
     expect(screen.getByLabelText("期限の時刻")).toBeDisabled()
   })
 
-  it("クリアボタン押下で due: null が送られる (モバイル native picker の代替)", async () => {
+  it("時刻クリアボタンで時刻だけ消えて日付は残る (モバイル native picker の代替)", async () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()
 
     render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", due: "2026-04-30T18:00:00.000+09:00" })} onClose={() => {}} />)
-    fireEvent.click(screen.getByRole("button", { name: "期限をクリア" }))
+    fireEvent.click(screen.getByRole("button", { name: "時刻をクリア" }))
 
     await waitFor(() => {
-      expect(mock).toHaveBeenCalledWith("t1", { due: null })
+      expect(mock).toHaveBeenCalledWith("t1", { due: "2026-04-30" })
     })
-    expect(screen.queryByRole("button", { name: "期限をクリア" })).not.toBeInTheDocument()
+    // クリア後はボタン自体も消える (time === "" のため)
+    expect(screen.queryByRole("button", { name: "時刻をクリア" })).not.toBeInTheDocument()
   })
 
   it("タイトル blur で updateTaskAction が呼ばれる", async () => {


### PR DESCRIPTION
## Summary

- 前回 PR #108 で追加したクリアボタンは日付・時刻の両方を消していたが、ユーザーの本当の困りごとは「時刻だけ消したい (日付は残したい)」だった。
- モバイル (iOS Safari の wheel picker など) では `<input type="time">` から値を空に戻す手段が露出していないことが本来の不便さ。クリアボタンを **time 側に紐付け**、時刻だけを消す挙動に変更する。
- 表示条件を `date` から `time` に変更。日付があっても時刻が空なら出さない。
- 押下: `onChange(date, "")` → `due` は `"YYYY-MM-DD"` で保存される (日付のみの ISO)。

## Test plan

- [x] `npm run test:unit` (279 件全パス、追加したテストを「時刻のみクリア」仕様に書き換え)
- [x] `npx playwright test` (snapshot 3 件以外パス、snapshot は main でも fail する既存フレーク)
- [ ] 視覚確認: 期限 (日付+時刻) を入れた状態でクリアボタン押下 → 時刻だけ消えて placeholder「時刻」が再表示、日付はそのまま残ることを確認

## Notes

- `data-testid` は `due-clear-button` → `due-time-clear-button` に変更。
- aria-label も「期限をクリア」→「時刻をクリア」に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)