### PR TITLE
feat(due-date): 日付クリアボタンも追加し、日付・時刻それぞれを個別に消せるようにする

### DIFF
--- a/src/components/DueDateTimeInput.tsx
+++ b/src/components/DueDateTimeInput.tsx
@@ -27,10 +27,11 @@ export function DueDateTimeInput({
     size === "compact" ? "px-3" : "px-4"
   }`
 
-  // モバイル (iOS Safari の wheel picker など) では <input type="time"> から値を
-  // 空に戻す手段が露出していないため、時刻のみを消す明示的なクリアボタンを置く。
-  // 日付はそのまま残す (日付なしの時刻は意味を持たない / 「期限なし」にしたい場合は
-  // 日付側を変更する)。
+  // モバイル (iOS Safari の wheel picker など) では <input type="date"> / <input
+  // type="time"> から値を空に戻す手段が露出していないため、各入力の右隣に明示的な
+  // クリアボタンを置く。日付ボタンは date 入力の native onChange と同じく
+  // 日付・時刻の両方を消す (日付なしの時刻は意味を持たないため)。
+  // 時刻ボタンは時刻のみを消し、日付は残す。
   const clearBtnClass = size === "compact" ? "icon-btn-sm" : "icon-btn"
 
   return (
@@ -48,6 +49,14 @@ export function DueDateTimeInput({
         />
         {!date && <span className={placeholderClass}>日付</span>}
       </div>
+      {date && (
+        <ClearButton
+          ariaLabel="日付をクリア"
+          testId="due-date-clear-button"
+          onClick={() => onChange("", "")}
+          className={clearBtnClass}
+        />
+      )}
       <div className="relative flex-1 min-w-0">
         <input
           type="time"
@@ -62,30 +71,51 @@ export function DueDateTimeInput({
         {!time && <span className={placeholderClass}>時刻</span>}
       </div>
       {time && (
-        <button
-          type="button"
+        <ClearButton
+          ariaLabel="時刻をクリア"
+          testId="due-time-clear-button"
           onClick={() => onChange(date, "")}
-          aria-label="時刻をクリア"
-          data-testid="due-time-clear-button"
           className={clearBtnClass}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <line x1="18" y1="6" x2="6" y2="18" />
-            <line x1="6" y1="6" x2="18" y2="18" />
-          </svg>
-        </button>
+        />
       )}
     </div>
+  )
+}
+
+function ClearButton({
+  ariaLabel,
+  testId,
+  onClick,
+  className,
+}: {
+  ariaLabel: string
+  testId: string
+  onClick: () => void
+  className: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className={className}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </button>
   )
 }

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -325,6 +325,20 @@ describe("TaskDetail フィールド変更", () => {
     expect(screen.queryByRole("button", { name: "時刻をクリア" })).not.toBeInTheDocument()
   })
 
+  it("日付クリアボタンで日付・時刻の両方が消えて due は null", async () => {
+    const mock = vi.mocked(updateTaskAction)
+    mock.mockClear()
+
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", due: "2026-04-30T18:00:00.000+09:00" })} onClose={() => {}} />)
+    fireEvent.click(screen.getByRole("button", { name: "日付をクリア" }))
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith("t1", { due: null })
+    })
+    expect(screen.queryByRole("button", { name: "日付をクリア" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "時刻をクリア" })).not.toBeInTheDocument()
+  })
+
   it("タイトル blur で updateTaskAction が呼ばれる", async () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()


### PR DESCRIPTION
## Summary

- 前回 PR #109 で時刻クリアボタンを追加したが、日付側もモバイル native では消す手段が無いため、**日付クリアボタンも追加**。
- レイアウトを `[日付] [×日付] [時刻] [×時刻]` に変更。各入力の右隣に対応するクリアボタンを置く。
- **日付クリア**: 日付・時刻の両方を消す (時刻だけ残しても意味が無いため、既存の date 入力 native onChange と同じ挙動 → `due: null`)。
- **時刻クリア**: 時刻のみ消し、日付は残す (前回 PR の挙動を維持 → `due: "YYYY-MM-DD"`)。
- X アイコン SVG はローカル `ClearButton` に抽出して共通化。

## Test plan

- [x] `npm run test:unit` (279 → 280 件、日付クリア用のテストを 1 件追加)
- [x] `npx playwright test` (snapshot 3 件以外パス、snapshot は main でも fail する既存フレーク)
- [ ] 視覚確認:
  - [ ] 期限あり (日付+時刻) で 2 個の X が並ぶ
  - [ ] 日付 X を押すと両方消えて placeholder「日付」「時刻」が再表示
  - [ ] 時刻 X を押すと時刻だけ消えて、日付はそのまま残る

## Notes

- 新 testid: `due-date-clear-button` / `due-time-clear-button`
- aria-label: 「日付をクリア」/「時刻をクリア」

🤖 Generated with [Claude Code](https://claude.com/claude-code)