### PR TITLE
fix(priority): タスクの優先度をクリアできるようにする

### DIFF
--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -326,7 +326,7 @@ export function TaskDetail({ task, tagOptions, allTasks = [], onSelectTask = () 
 
   function handlePriorityChange(next: TaskPriority | "") {
     setEditPriority(next)
-    save({ priority: next || undefined })
+    save({ priority: next || null })
   }
 
   function handleDueChange(date: string, time: string) {

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -224,6 +224,19 @@ describe("TaskDetail フィールド変更", () => {
     })
   })
 
+  it("Priority を「未設定」にすると priority: null で更新される", async () => {
+    const mock = vi.mocked(updateTaskAction)
+    mock.mockClear()
+
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask({ id: "t1", priority: "high" })} onClose={() => {}} />)
+    const selects = screen.getAllByRole("combobox")
+    fireEvent.change(selects[1], { target: { value: "" } })
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith("t1", { priority: null })
+    })
+  })
+
   it("タグトグルで updateTaskAction が即時呼ばれる", async () => {
     const mock = vi.mocked(updateTaskAction)
     mock.mockClear()

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -227,7 +227,7 @@ export async function updateTask(id: string, input: UpdateTaskInput): Promise<Ta
 
   if (input.title !== undefined)    properties[NOTION_PROPS.TITLE]      = { title: [{ text: { content: input.title } }] }
   if (input.status !== undefined)   properties[NOTION_PROPS.STATUS]     = { status: { name: input.status } }
-  if (input.priority !== undefined) properties[NOTION_PROPS.PRIORITY]   = { select: { name: input.priority } }
+  if (input.priority !== undefined) properties[NOTION_PROPS.PRIORITY]   = input.priority ? { select: { name: input.priority } } : { select: null }
   if (input.due !== undefined)      properties[NOTION_PROPS.DUE]        = input.due ? { date: { start: input.due } } : { date: null }
   if (input.tags !== undefined)     properties[NOTION_PROPS.TAG]        = { multi_select: input.tags.map((t) => ({ name: t })) }
   if (input.source !== undefined)   properties[NOTION_PROPS.SOURCE]     = { rich_text: [{ text: { content: input.source } }] }

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -39,7 +39,7 @@ export type Task = {
 export type CreateTaskInput = {
   title: string
   status?: TaskStatus
-  priority?: TaskPriority
+  priority?: TaskPriority | null
   due?: string | null
   tags?: string[]
   body?: string


### PR DESCRIPTION
## Summary
- 優先度設定のあるタスクで「未設定」を選んでも反映されなかった不具合を修正
- 期限フィールドと同じ null 渡しパターンに揃え、Notion 側を `{ select: null }` でクリアするように変更

## 原因
- `TaskDetail.tsx` の `handlePriorityChange` が空文字を `undefined` に変換して送信
- `updateTask` 側の `if (input.priority !== undefined)` ガードによってクリア要求が無視されていた

## Test plan
- [x] 既存ユニットテスト 281 件パス
- [x] Priority を「未設定」にすると `priority: null` で更新されることを確認する回帰テストを追加
- [x] Playwright e2e — 既存の iPhone 15 (touch) snapshot 3 件は main でも同様に失敗する pre-existing issue で、本変更とは無関係
- [ ] 実機 / Docker で priority=high のタスクを開き「未設定」に切替後、再読み込みしてもクリア状態が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)