### PR TITLE
fix(board): PC レイアウトでバックログが左端で見切れる問題を修正

### DIFF
--- a/src/components/TaskBoard.tsx
+++ b/src/components/TaskBoard.tsx
@@ -49,6 +49,9 @@ export const TaskBoard = forwardRef<
   // 起動時のスクロール位置を WIP カラムに合わせる。バックログは左端だが「退避列」で、
   // 開いた直後にユーザーが見たいのは進行中/未着手のため。paint 前に scrollLeft を当てて
   // 一瞬左端 (バックログ) が見えるチラつきを防ぐ。
+  // ただし viewport が広く maxScroll < バックログ幅 のときは scrollLeft がクランプされて
+  // バックログが左端で半分だけ見える「見切れ」状態になる。その場合は scroll を当てず
+  // 全カラムを左から自然に並べる (PC 等の広い画面で発生)。
   useLayoutEffect(() => {
     const container = containerRef.current
     if (!container) return
@@ -56,6 +59,8 @@ export const TaskBoard = forwardRef<
       `[data-column-key="${INITIAL_FOCUS_COLUMN_KEY}"]`,
     )
     if (!focus) return
+    const maxScroll = container.scrollWidth - container.clientWidth
+    if (maxScroll < focus.offsetLeft) return
     container.scrollLeft = focus.offsetLeft
   }, [])
 


### PR DESCRIPTION
## Summary
- viewport が広く `maxScroll < WIP の offsetLeft (360px)` になる PC レイアウトで、`scrollLeft` がブラウザにクランプされバックログが左端で半分だけ覗く「見切れ」状態になっていた
- 例: 1920x1080 では `scrollLeft=240` (360 から 240 にクランプ) → バックログが x=-240 で 120px 露出
- `maxScroll < focus.offsetLeft` の場合はスクロールを当てず全カラムを左から自然に並べる。狭い viewport では従来通り WIP に寄せる

## Test plan
- [x] `npm run test:unit` — 286 passed
- [x] `npx playwright test` — 41 passed
- [x] viewport 別の挙動確認 (アドホック spec で検証後削除)
  - 1920×1080 → `scrollLeft=0` / backlog 完全表示
  - 1800×1080 → `scrollLeft=360` (WIP 起点、従来通り)
  - 1440/1280/800px → `scrollLeft=360` (WIP 起点、従来通り)

🤖 Generated with [Claude Code](https://claude.com/claude-code)