### PR TITLE
feat(board): 親タスク単位でサブタスクの表示/非表示をトグル (#115)

### DIFF
--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -1,11 +1,11 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { AdvancedFilter, SortConfig, Task, TaskStatus } from "@/types/task"
 import { TaskItem } from "./TaskItem"
 import { applyAdvancedFilter } from "@/constants/filters"
 import { applySort } from "@/lib/task-sort"
-import { buildNestedOrder } from "@/lib/task-tree"
+import { buildNestedOrder, filterCollapsed } from "@/lib/task-tree"
 import { STATUS_ACCENT } from "@/constants/styles"
 import { getCompletedTasksAction, getCancelledTasksAction, getBacklogTasksAction } from "@/app/actions"
 import { CyberLoader } from "./CyberLoader"
@@ -133,6 +133,30 @@ export function BoardColumn({
   // 親が同じ列に居なければ子はルートとして残るので、一覧から消えることはない。
   const nested = useMemo(() => buildNestedOrder(filtered), [filtered])
 
+  const [collapsedParents, setCollapsedParents] = useState<Set<string>>(new Set())
+
+  const handleToggleCollapse = useCallback((taskId: string) => {
+    setCollapsedParents((prev) => {
+      const next = new Set(prev)
+      next.has(taskId) ? next.delete(taskId) : next.add(taskId)
+      return next
+    })
+  }, [])
+
+  // 同カラム内に直接の子を持つ親 ID のセット（トグルボタン表示判定用）
+  const parentIdsWithChildren = useMemo(() => {
+    const set = new Set<string>()
+    for (let i = 0; i < nested.length - 1; i++) {
+      if (nested[i + 1].depth > nested[i].depth) set.add(nested[i].task.id)
+    }
+    return set
+  }, [nested])
+
+  const nestedFiltered = useMemo(
+    () => (collapsedParents.size === 0 ? nested : filterCollapsed(nested, collapsedParents)),
+    [nested, collapsedParents]
+  )
+
   const accent = STATUS_ACCENT[accentStatus]
   const isLazyPending = isLazyStatus && !propsHasLazy && lazyTasks === null
   const showLazyLoading = isLazyPending && !hasLoadError
@@ -147,10 +171,10 @@ export function BoardColumn({
   useEffect(() => {
     if (!isLazyStatus) return
     setDisplayCount(INCREMENTAL_INITIAL)
-  }, [isLazyStatus, nested])
+  }, [isLazyStatus, nestedFiltered])
 
-  const visible = isLazyStatus ? nested.slice(0, displayCount) : nested
-  const hasMore = isLazyStatus && displayCount < nested.length
+  const visible = isLazyStatus ? nestedFiltered.slice(0, displayCount) : nestedFiltered
+  const hasMore = isLazyStatus && displayCount < nestedFiltered.length
 
   // 末尾 sentinel が見えたら次の chunk をロード。スクロール親 (overflow-y-auto) を
   // root にする。rootMargin: 200px で下端到達前に先読みして体感を滑らかに。
@@ -235,10 +259,22 @@ export function BoardColumn({
                     className="border-l border-[var(--border-strong)] pl-3"
                     style={{ marginLeft: depth * 16 }}
                   >
-                    <TaskItem task={task} onSelect={onSelect} />
+                    <TaskItem
+                      task={task}
+                      onSelect={onSelect}
+                      isCollapsible={parentIdsWithChildren.has(task.id)}
+                      isCollapsed={collapsedParents.has(task.id)}
+                      onToggleCollapse={handleToggleCollapse}
+                    />
                   </div>
                 ) : (
-                  <TaskItem task={task} onSelect={onSelect} />
+                  <TaskItem
+                    task={task}
+                    onSelect={onSelect}
+                    isCollapsible={parentIdsWithChildren.has(task.id)}
+                    isCollapsed={collapsedParents.has(task.id)}
+                    onToggleCollapse={handleToggleCollapse}
+                  />
                 )}
               </li>
             ))}

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -13,7 +13,19 @@ import { useTasksRefresh } from "./TasksRefreshContext"
 //
 // memo: 検索打鍵 / フィルタ・ソート切替 / refresh 後に親で tasks 配列が新しく
 // なるが、要素の参照 (task) が変わらない限り再 render を skip。多数カードの jank 軽減。
-export const TaskItem = memo(function TaskItem({ task, onSelect }: { task: Task; onSelect: (task: Task) => void }) {
+export const TaskItem = memo(function TaskItem({
+  task,
+  onSelect,
+  isCollapsible = false,
+  isCollapsed = false,
+  onToggleCollapse,
+}: {
+  task: Task
+  onSelect: (task: Task) => void
+  isCollapsible?: boolean
+  isCollapsed?: boolean
+  onToggleCollapse?: (taskId: string) => void
+}) {
   const [, startTransition] = useTransition()
   const [optimisticStatus, setOptimisticStatus] = useOptimistic(task.status)
   const selectRef = useRef<HTMLSelectElement>(null)
@@ -122,9 +134,18 @@ export const TaskItem = memo(function TaskItem({ task, onSelect }: { task: Task;
               +{task.tags.length - 2}
             </span>
           )}
-          {task.childTaskIds.length > 0 && (
+          {isCollapsible ? (
+            <button
+              onClick={(e) => { e.stopPropagation(); onToggleCollapse?.(task.id) }}
+              className="font-pixel text-[11px] text-[var(--text-faint)] flex items-center gap-1"
+              aria-label={isCollapsed ? "サブタスクを展開" : "サブタスクを折りたたむ"}
+            >
+              <span aria-hidden="true">{isCollapsed ? "▶" : "▼"}</span>
+              <span>子{task.childTaskIds.length}件</span>
+            </button>
+          ) : task.childTaskIds.length > 0 ? (
             <span className="text-[11px] text-[var(--text-faint)]">子{task.childTaskIds.length}件</span>
-          )}
+          ) : null}
         </div>
       )}
 

--- a/src/lib/task-tree.ts
+++ b/src/lib/task-tree.ts
@@ -49,3 +49,25 @@ export function buildNestedOrder(tasks: Task[]): NestedTaskNode[] {
 
   return out
 }
+
+// collapsed な親タスクの子孫を nested リストから除去する。
+// nested は DFS 順なので、depth が増えている連続区間が子孫に対応する。
+export function filterCollapsed(
+  nested: NestedTaskNode[],
+  collapsedParents: Set<string>
+): NestedTaskNode[] {
+  const result: NestedTaskNode[] = []
+  let skipAboveDepth: number | null = null
+
+  for (const node of nested) {
+    if (skipAboveDepth !== null) {
+      if (node.depth > skipAboveDepth) continue
+      skipAboveDepth = null
+    }
+    result.push(node)
+    if (collapsedParents.has(node.task.id)) {
+      skipAboveDepth = node.depth
+    }
+  }
+  return result
+}


### PR DESCRIPTION
## Summary

- 同カラム内に子タスクを持つ親タスクのカードに **▼/▶ 子X件** ボタンを追加
- クリックで子タスクを折りたたみ/展開（カラム単位でセッションローカルに保持）
- 他カラムにのみ子がいるタスクは従来通り plain バッジのまま

## 実装

- `src/lib/task-tree.ts` — `filterCollapsed()` ヘルパーを追加（DFS 順の nested リストから collapsed 親の子孫をスキップ）
- `src/components/BoardColumn.tsx` — `collapsedParents` state・`handleToggleCollapse` コールバック・`parentIdsWithChildren` セットを追加し、`nestedFiltered` で表示リストを制御
- `src/components/TaskItem.tsx` — `isCollapsible` / `isCollapsed` / `onToggleCollapse` props を追加し、クリッカブルなトグルボタンを表示

## Test plan

- [x] `npm run test:unit` — 286 passed
- [x] `npx playwright test` — 41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)