### PR TITLE
feat(board): サブタスクのトグル状態を localStorage に永続化する (#116)

### DIFF
--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -133,7 +133,25 @@ export function BoardColumn({
   // 親が同じ列に居なければ子はルートとして残るので、一覧から消えることはない。
   const nested = useMemo(() => buildNestedOrder(filtered), [filtered])
 
-  const [collapsedParents, setCollapsedParents] = useState<Set<string>>(new Set())
+  const storageKey = `subtask-collapsed-${columnKey}`
+
+  const [collapsedParents, setCollapsedParents] = useState<Set<string>>(() => {
+    if (typeof window === "undefined") return new Set()
+    try {
+      const raw = localStorage.getItem(storageKey)
+      return raw ? new Set(JSON.parse(raw) as string[]) : new Set()
+    } catch {
+      return new Set()
+    }
+  })
+
+  useEffect(() => {
+    if (collapsedParents.size === 0) {
+      localStorage.removeItem(storageKey)
+    } else {
+      localStorage.setItem(storageKey, JSON.stringify([...collapsedParents]))
+    }
+  }, [collapsedParents, storageKey])
 
   const handleToggleCollapse = useCallback((taskId: string) => {
     setCollapsedParents((prev) => {


### PR DESCRIPTION
## Summary

- サブタスクの折りたたみ/展開状態をページリロード後も維持できるようにした
- localStorage キー `subtask-collapsed-${columnKey}` に折りたたみ中の親タスク ID を保存
- 全展開状態に戻したときはキーを `removeItem` で削除

## 実装

`src/components/BoardColumn.tsx` のみ変更:
- `useState` の lazy initializer で localStorage から初期値を復元
- `useEffect` で `collapsedParents` 変更のたびに localStorage へ書き戻し

## Test plan

- [x] `npm run test:unit` — 286 passed
- [x] `npx playwright test` — 41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)