### PR TITLE
feat(task-detail): タスクを別タスクのサブタスクに変換できるようにする

### DIFF
--- a/e2e/task-detail.spec.ts
+++ b/e2e/task-detail.spec.ts
@@ -149,3 +149,86 @@ test.describe("サブタスク", () => {
     ).toBeVisible({ timeout: 10_000 })
   })
 })
+
+test.describe("親タスク変更", () => {
+  test.describe.configure({ mode: "serial" })
+
+  let context: BrowserContext
+  let page: Page
+
+  // 初期データのうち、独立した 2 タスクを使う。
+  const TARGET_TITLE = "【DEV】ルーターのファームウェア更新"
+  const NEW_PARENT_TITLE = "【DEV】サーバー監視ダッシュボード改善"
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext({ storageState: AUTH_FILE })
+    page = await context.newPage()
+    await resetAndOpenHome(page)
+  })
+
+  test.afterAll(async () => {
+    await context.close()
+  })
+
+  async function openTaskDetail(title: string) {
+    await page
+      .locator(`${BOARD} ${TASK_ITEM} [data-testid='task-title']`, { hasText: title })
+      .first()
+      .click()
+    await expect(page.locator(TASK_DETAIL)).toBeVisible({ timeout: 5_000 })
+    await expect(page.locator('input[aria-label="タイトル"]')).toHaveValue(title, { timeout: 5_000 })
+  }
+
+  async function closeDetailIfOpen() {
+    const detail = page.locator(TASK_DETAIL)
+    if (await detail.isVisible().catch(() => false)) {
+      await page.locator(TASK_DETAIL_BACKDROP).click({ position: { x: 10, y: 10 } })
+      await detail.waitFor({ state: "hidden", timeout: 5_000 })
+    }
+  }
+
+  test.beforeEach(async () => {
+    await closeDetailIfOpen()
+  })
+
+  test("親タスクを設定するとサブタスクとして反映される", async () => {
+    await openTaskDetail(TARGET_TITLE)
+
+    await page.locator("[data-testid='parent-set-button']").click()
+    await expect(page.locator("[data-testid='parent-picker-modal']")).toBeVisible({ timeout: 5_000 })
+
+    await page.locator("[data-testid='parent-picker-search']").fill("サーバー監視")
+    const candidate = page
+      .locator("[data-testid='parent-picker-candidate']", { hasText: NEW_PARENT_TITLE })
+      .first()
+    await candidate.click()
+
+    await expect(page.locator("[data-testid='parent-picker-modal']")).not.toBeVisible({ timeout: 5_000 })
+    await expect(
+      page.locator("[data-testid='parent-task-item']", { hasText: NEW_PARENT_TITLE }),
+    ).toBeVisible({ timeout: 5_000 })
+
+    // 親側からサブタスクとして見えること
+    await page.locator("[data-testid='parent-task-item']", { hasText: NEW_PARENT_TITLE }).click()
+    await expect(page.locator('input[aria-label="タイトル"]')).toHaveValue(NEW_PARENT_TITLE, { timeout: 5_000 })
+    await expect(
+      page.locator("[data-testid='subtask-item']", { hasText: TARGET_TITLE }),
+    ).toBeVisible({ timeout: 5_000 })
+  })
+
+  test("親を解除すると親タスク行が消える", async () => {
+    await openTaskDetail(TARGET_TITLE)
+
+    await expect(
+      page.locator("[data-testid='parent-task-item']", { hasText: NEW_PARENT_TITLE }),
+    ).toBeVisible({ timeout: 5_000 })
+
+    await page.locator("[data-testid='parent-set-button']").click()
+    await page.locator("[data-testid='parent-picker-clear']").click()
+
+    await expect(page.locator("[data-testid='parent-picker-modal']")).not.toBeVisible({ timeout: 5_000 })
+    await expect(
+      page.locator("[data-testid='parent-task-item']", { hasText: NEW_PARENT_TITLE }),
+    ).not.toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/src/components/ParentTaskPickerModal.tsx
+++ b/src/components/ParentTaskPickerModal.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import type { Task } from "@/types/task"
+import { STATUS_ACCENT } from "@/constants/styles"
+import type { CSSProperties } from "react"
+
+export function ParentTaskPickerModal({
+  open,
+  onClose,
+  currentTask,
+  allTasks,
+  onSelect,
+}: {
+  open: boolean
+  onClose: () => void
+  currentTask: Task
+  allTasks: Task[]
+  onSelect: (parentId: string | null) => void
+}) {
+  const [query, setQuery] = useState("")
+
+  useEffect(() => {
+    if (!open) return
+    setQuery("")
+    const prev = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => { document.body.style.overflow = prev }
+  }, [open])
+
+  const excluded = useMemo(() => collectExcludedIds(currentTask, allTasks), [currentTask, allTasks])
+  const hasParent = currentTask.parentTaskIds.length > 0
+
+  const candidates = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return allTasks
+      .filter((t) => !excluded.has(t.id))
+      .filter((t) => (needle ? t.title.toLowerCase().includes(needle) : true))
+      .slice(0, 50)
+  }, [allTasks, excluded, query])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex flex-col justify-end"
+      data-testid="parent-picker-modal"
+    >
+      <div className="absolute inset-0 bg-black/70" onClick={onClose} data-testid="parent-picker-backdrop" />
+
+      <div
+        className="relative rounded-t-2xl px-4 pt-4 pb-8 safe-bottom max-h-[85svh] overflow-y-auto overscroll-contain"
+        style={{
+          backgroundColor: "var(--surface)",
+          borderTop: "1px solid var(--border-strong)",
+          boxShadow: "0 -8px 40px rgba(0,0,0,0.5)",
+        }}
+      >
+        <div className="w-10 h-1 rounded-full mx-auto mb-4" style={{ backgroundColor: "var(--border-strong)" }} />
+
+        <h2 className="font-pixel text-sm text-[var(--accent)] tracking-widest uppercase mb-4 accent-glow-text-sm">
+          ✦ Set Parent
+        </h2>
+
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="タイトルで検索"
+          autoFocus
+          className="field w-full mb-4"
+          data-testid="parent-picker-search"
+        />
+
+        <div className="flex flex-col gap-2">
+          {candidates.length === 0 && (
+            <p className="text-sm text-[var(--text-faint)] py-4 text-center">
+              {query ? "該当するタスクがありません" : "候補となるタスクがありません"}
+            </p>
+          )}
+          {candidates.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              data-testid="parent-picker-candidate"
+              data-task-id={t.id}
+              onClick={() => {
+                onSelect(t.id)
+                onClose()
+              }}
+              className="flex items-center gap-2 w-full text-left rounded-lg border border-[var(--border-strong)] bg-[var(--surface-2)] px-3 py-2 hover:border-[var(--border-accent)] transition-colors"
+              style={{ minHeight: "var(--tap-min)" }}
+            >
+              {t.icon && (
+                t.icon.type === "emoji" ? (
+                  <span aria-hidden="true" className="flex-shrink-0 text-base leading-none">{t.icon.emoji}</span>
+                ) : (
+                  <img src={t.icon.url} alt="" className="flex-shrink-0 w-4 h-4 rounded object-cover" />
+                )
+              )}
+              <span className="flex-1 min-w-0 text-sm text-[var(--text)] break-words">{t.title}</span>
+              <span
+                aria-hidden="true"
+                className="status-dot flex-shrink-0"
+                style={{ "--status-color": STATUS_ACCENT[t.status ?? "未着手"] } as CSSProperties}
+              />
+            </button>
+          ))}
+        </div>
+
+        {hasParent && (
+          <button
+            type="button"
+            data-testid="parent-picker-clear"
+            onClick={() => {
+              onSelect(null)
+              onClose()
+            }}
+            className="font-pixel mt-4 flex items-center justify-center gap-2 w-full rounded-lg py-3 text-xs text-[var(--text-dim)] hover:text-[var(--status-cancel)] hover:border-[var(--status-cancel)] transition-colors tracking-widest uppercase"
+            style={{ border: "1px solid var(--border-strong)", minHeight: "var(--tap-min)" }}
+          >
+            親を解除
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="font-pixel mt-4 flex items-center justify-center gap-2 w-full rounded-lg py-3 text-xs text-[var(--text-dim)] hover:text-[var(--accent)] transition-colors tracking-widest uppercase"
+          style={{ border: "1px solid var(--border-strong)", minHeight: "var(--tap-min)" }}
+        >
+          キャンセル
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// 自タスク + その子孫を候補から除外する（循環防止）。
+// 双方向 relation のため childTaskIds と parentTaskIds 両側から辿る。
+function collectExcludedIds(root: Task, allTasks: Task[]): Set<string> {
+  const byId = new Map(allTasks.map((t) => [t.id, t]))
+  const excluded = new Set<string>([root.id])
+  const queue: string[] = [root.id]
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    const node = byId.get(id)
+    const childIds = new Set<string>(node?.childTaskIds ?? [])
+    for (const t of allTasks) {
+      if (t.parentTaskIds.includes(id)) childIds.add(t.id)
+    }
+    for (const cid of childIds) {
+      if (!excluded.has(cid)) {
+        excluded.add(cid)
+        queue.push(cid)
+      }
+    }
+  }
+  return excluded
+}

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -5,6 +5,7 @@ import type { Task, TaskComment, TaskStatus, TaskPriority } from "@/types/task"
 import { updateTaskAction, getTaskBlocksAction, updateTaskBlocksAction, getTaskCommentsAction, createTaskCommentAction, getTasksByIdsAction } from "@/app/actions"
 import { STATUS_OPTIONS, STATUS_STYLES, STATUS_ACCENT } from "@/constants/styles"
 import { TaskFormSheet } from "./TaskFormSheet"
+import { ParentTaskPickerModal } from "./ParentTaskPickerModal"
 import { MarkdownPreview } from "./MarkdownPreview"
 import { parseDue, buildDue, snapTimeTo5Min, formatDueShort } from "@/lib/due-date"
 import { DueDateTimeInput } from "./DueDateTimeInput"
@@ -26,6 +27,7 @@ export function TaskDetail({ task, tagOptions, allTasks = [], onSelectTask = () 
   // lazy fetch 未取得) は getTasksByIdsAction で補完する。
   const [extraTasks, setExtraTasks] = useState<Record<string, Task>>({})
   const [subtaskFormOpen, setSubtaskFormOpen] = useState(false)
+  const [parentPickerOpen, setParentPickerOpen] = useState(false)
 
   const taskById = useMemo(() => {
     const m = new Map<string, Task>()
@@ -459,15 +461,22 @@ export function TaskDetail({ task, tagOptions, allTasks = [], onSelectTask = () 
             </Row>
           )}
 
-          {parentTasks.length > 0 && (
-            <Row label="親タスク" block>
-              <div className="flex flex-col gap-2">
-                {parentTasks.map((p) => (
-                  <RelatedTaskRow key={p.id} task={p} testid="parent-task-item" onClick={() => onSelectTask(p)} />
-                ))}
-              </div>
-            </Row>
-          )}
+          <Row label="親タスク" block>
+            <div className="flex flex-col gap-2">
+              {parentTasks.map((p) => (
+                <RelatedTaskRow key={p.id} task={p} testid="parent-task-item" onClick={() => onSelectTask(p)} />
+              ))}
+              <button
+                type="button"
+                data-testid="parent-set-button"
+                onClick={() => setParentPickerOpen(true)}
+                className="font-pixel flex items-center justify-center gap-2 w-full rounded-lg py-3 text-xs text-[var(--text-dim)] hover:text-[var(--accent)] hover:border-[var(--border-accent)] transition-colors tracking-widest uppercase"
+                style={{ border: "1px solid var(--border-strong)", minHeight: "var(--tap-min)" }}
+              >
+                {parentTasks.length > 0 ? "親タスクを変更" : "+ 親タスクを設定"}
+              </button>
+            </div>
+          </Row>
 
           <div data-testid="subtask-section">
             <Row label="サブタスク" block>
@@ -653,6 +662,14 @@ export function TaskDetail({ task, tagOptions, allTasks = [], onSelectTask = () 
         parentTaskId={task.id}
         heading="✦ New Subtask"
         submitLabel="ADD SUBTASK"
+      />
+
+      <ParentTaskPickerModal
+        open={parentPickerOpen}
+        onClose={() => setParentPickerOpen(false)}
+        currentTask={task}
+        allTasks={allTasks}
+        onSelect={(parentId) => save({ parentTaskId: parentId })}
       />
     </div>
   )

--- a/src/components/__tests__/TaskDetail.test.tsx
+++ b/src/components/__tests__/TaskDetail.test.tsx
@@ -687,3 +687,121 @@ describe("TaskDetail サブタスク", () => {
     expect(screen.getByRole("button", { name: /ADD SUBTASK/i })).toBeInTheDocument()
   })
 })
+
+describe("TaskDetail 親タスク変更", () => {
+  it("親なし状態では「+ 親タスクを設定」ボタンが出る", () => {
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} onClose={() => {}} />)
+    const button = screen.getByTestId("parent-set-button")
+    expect(button).toHaveTextContent("+ 親タスクを設定")
+  })
+
+  it("親あり状態では「親タスクを変更」ボタンが出る", () => {
+    const parent = makeTask({ id: "p", title: "親" })
+    const child = makeTask({ id: "c", parentTaskIds: ["p"] })
+    render(
+      <TaskDetail tagOptions={TAG_OPTIONS} task={child} allTasks={[parent, child]} onClose={() => {}} />,
+    )
+    expect(screen.getByTestId("parent-set-button")).toHaveTextContent("親タスクを変更")
+  })
+
+  it("候補選択で updateTaskAction が parentTaskId 付きで呼ばれる", async () => {
+    const self = makeTask({ id: "self" })
+    const candidate = makeTask({ id: "cand", title: "候補タスク" })
+
+    render(
+      <TaskDetail tagOptions={TAG_OPTIONS} task={self} allTasks={[self, candidate]} onClose={() => {}} />,
+    )
+
+    fireEvent.click(screen.getByTestId("parent-set-button"))
+    expect(screen.getByTestId("parent-picker-modal")).toBeInTheDocument()
+
+    const candidateButton = screen.getByText("候補タスク").closest("button")!
+    await act(async () => {
+      fireEvent.click(candidateButton)
+    })
+
+    await waitFor(() => {
+      expect(vi.mocked(updateTaskAction)).toHaveBeenCalledWith("self", { parentTaskId: "cand" })
+    })
+  })
+
+  it("親を解除すると updateTaskAction が parentTaskId: null で呼ばれる", async () => {
+    const parent = makeTask({ id: "p", title: "親" })
+    const child = makeTask({ id: "c", parentTaskIds: ["p"] })
+
+    render(
+      <TaskDetail tagOptions={TAG_OPTIONS} task={child} allTasks={[parent, child]} onClose={() => {}} />,
+    )
+
+    fireEvent.click(screen.getByTestId("parent-set-button"))
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("parent-picker-clear"))
+    })
+
+    await waitFor(() => {
+      expect(vi.mocked(updateTaskAction)).toHaveBeenCalledWith("c", { parentTaskId: null })
+    })
+  })
+
+  it("自タスクは候補に出ない", () => {
+    const self = makeTask({ id: "self", title: "自分自身のタスク" })
+    const other = makeTask({ id: "o", title: "他人のタスク" })
+
+    render(
+      <TaskDetail tagOptions={TAG_OPTIONS} task={self} allTasks={[self, other]} onClose={() => {}} />,
+    )
+
+    fireEvent.click(screen.getByTestId("parent-set-button"))
+    const candidates = screen.getAllByTestId("parent-picker-candidate")
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]).toHaveAttribute("data-task-id", "o")
+  })
+
+  it("自タスクの子・孫は候補に出ない（循環防止）", () => {
+    const self = makeTask({ id: "p" })
+    const child = makeTask({ id: "c", title: "子", parentTaskIds: ["p"] })
+    const grandchild = makeTask({ id: "g", title: "孫", parentTaskIds: ["c"] })
+    const other = makeTask({ id: "o", title: "他人" })
+
+    render(
+      <TaskDetail
+        tagOptions={TAG_OPTIONS}
+        task={self}
+        allTasks={[self, child, grandchild, other]}
+        onClose={() => {}}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId("parent-set-button"))
+    const candidates = screen.getAllByTestId("parent-picker-candidate")
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]).toHaveAttribute("data-task-id", "o")
+  })
+
+  it("タイトル検索で候補が絞り込まれる", () => {
+    const self = makeTask({ id: "self" })
+    const tasks = [
+      self,
+      makeTask({ id: "a", title: "買い物リスト" }),
+      makeTask({ id: "b", title: "ブログ執筆" }),
+      makeTask({ id: "c", title: "買い替え検討" }),
+    ]
+
+    render(
+      <TaskDetail tagOptions={TAG_OPTIONS} task={self} allTasks={tasks} onClose={() => {}} />,
+    )
+
+    fireEvent.click(screen.getByTestId("parent-set-button"))
+    fireEvent.change(screen.getByTestId("parent-picker-search"), { target: { value: "買い" } })
+
+    const candidates = screen.getAllByTestId("parent-picker-candidate")
+    expect(candidates).toHaveLength(2)
+    expect(candidates.map((c) => c.getAttribute("data-task-id"))).toEqual(["a", "c"])
+  })
+
+  it("親なしのとき「親を解除」ボタンは出ない", () => {
+    render(<TaskDetail tagOptions={TAG_OPTIONS} task={makeTask()} allTasks={[]} onClose={() => {}} />)
+    fireEvent.click(screen.getByTestId("parent-set-button"))
+    expect(screen.queryByTestId("parent-picker-clear")).not.toBeInTheDocument()
+  })
+})

--- a/src/lib/mock-tasks.ts
+++ b/src/lib/mock-tasks.ts
@@ -348,5 +348,23 @@ export function updateMockTask(id: string, input: UpdateTaskInput): Task | null 
     ...(input.sourceUrl !== undefined && { sourceUrl: input.sourceUrl }),
     lastEditedTime: ts,
   }
+  // 双方向 relation の同期模倣: 旧親の childTaskIds から自分を抜き、新親に追加する。
+  if (input.parentTaskId !== undefined) {
+    const prevParents = store[idx].parentTaskIds
+    for (const pid of prevParents) {
+      const p = store.find((t) => t.id === pid)
+      if (p) p.childTaskIds = p.childTaskIds.filter((c) => c !== id)
+    }
+    store[idx] = {
+      ...store[idx],
+      parentTaskIds: input.parentTaskId ? [input.parentTaskId] : [],
+    }
+    if (input.parentTaskId) {
+      const parent = store.find((t) => t.id === input.parentTaskId)
+      if (parent && !parent.childTaskIds.includes(id)) {
+        parent.childTaskIds = [...parent.childTaskIds, id]
+      }
+    }
+  }
   return store[idx]
 }

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -232,6 +232,9 @@ export async function updateTask(id: string, input: UpdateTaskInput): Promise<Ta
   if (input.tags !== undefined)     properties[NOTION_PROPS.TAG]        = { multi_select: input.tags.map((t) => ({ name: t })) }
   if (input.source !== undefined)   properties[NOTION_PROPS.SOURCE]     = { rich_text: [{ text: { content: input.source } }] }
   if (input.sourceUrl !== undefined) properties[NOTION_PROPS.SOURCE_URL] = { url: input.sourceUrl }
+  if (input.parentTaskId !== undefined) properties[NOTION_PROPS.PARENT] = {
+    relation: input.parentTaskId ? [{ id: input.parentTaskId }] : [],
+  }
 
   const page = await notion.pages.update({
     page_id: id,

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -49,7 +49,17 @@ export type CreateTaskInput = {
   parentTaskId?: string
 }
 
-export type UpdateTaskInput = Partial<Omit<CreateTaskInput, "title"> & { title: string }>
+export type UpdateTaskInput = {
+  title?: string
+  status?: TaskStatus
+  priority?: TaskPriority | null
+  due?: string | null
+  tags?: string[]
+  body?: string
+  source?: string
+  sourceUrl?: string
+  parentTaskId?: string | null
+}
 
 export type TaskComment = {
   id: string


### PR DESCRIPTION
## Summary
- タスク詳細パネル「親タスク」セクションに「+ 親タスクを設定 / 親タスクを変更」ボタンを追加し、タイトル検索モーダルから既存タスクを親として指定できるようにした
- Notion の PARENT relation を更新する経路を `updateTask` に追加（`parentTaskId: null` で解除）
- 循環防止: 自タスクとその子孫はモーダルの候補から除外

## Test plan
- [x] ユニットテスト: `npm run test:unit`（294 passed）
- [x] Playwright: `npx playwright test`（45 passed、iPhone15 + Desktop Chrome）
- [x] 親変更 e2e: TARGET を別タスクの子に付け替え → 親側の subtask 一覧に表示されること
- [x] 親解除 e2e: 「親を解除」で `parent-task-item` が消えること
- [x] unit: 自タスクおよび子孫が候補に出ないこと（循環防止）

🤖 Generated with [Claude Code](https://claude.com/claude-code)