### PR TITLE
fix(task-detail): ファイルアップロードエラーを修正

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -4,6 +4,7 @@ import { updateTag } from "next/cache"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { auth } from "@/auth"
+import { isNotionClientError } from "@notionhq/client"
 import { updateTask, createTask, getTask, getTaskBlocks, updateTaskBlocks, getTaskComments, createTaskComment, getTasks, getTagOptions, uploadTaskAttachment, removeTaskAttachment } from "@/lib/notion"
 import type { AdvancedFilter, SortConfig, Task, TaskAttachment, TaskStatus, TaskComment, CreateTaskInput, UpdateTaskInput } from "@/types/task"
 
@@ -110,9 +111,17 @@ export async function uploadTaskAttachmentAction(
   await requireAuth()
   const file = formData.get("file")
   if (!(file instanceof File)) throw new Error("ファイルが見つかりません")
-  const attachments = await uploadTaskAttachment(taskId, file)
-  updateTag("tasks")
-  return attachments
+  try {
+    const attachments = await uploadTaskAttachment(taskId, file)
+    updateTag("tasks")
+    return attachments
+  } catch (e) {
+    console.error("[uploadTaskAttachmentAction] failed:", e)
+    if (isNotionClientError(e)) {
+      throw new Error(`Notion エラー: ${e.message}`)
+    }
+    throw e
+  }
 }
 
 export async function removeTaskAttachmentAction(
@@ -120,7 +129,15 @@ export async function removeTaskAttachmentAction(
   index: number,
 ): Promise<TaskAttachment[]> {
   await requireAuth()
-  const attachments = await removeTaskAttachment(taskId, index)
-  updateTag("tasks")
-  return attachments
+  try {
+    const attachments = await removeTaskAttachment(taskId, index)
+    updateTag("tasks")
+    return attachments
+  } catch (e) {
+    console.error("[removeTaskAttachmentAction] failed:", e)
+    if (isNotionClientError(e)) {
+      throw new Error(`Notion エラー: ${e.message}`)
+    }
+    throw e
+  }
 }

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -780,32 +780,59 @@ export async function uploadTaskAttachment(pageId: string, file: File): Promise<
   }
 
   // 1. File Upload を作成
-  const upload = await notion.fileUploads.create({
-    mode: "single_part",
-    filename: file.name,
-    content_type: file.type || "application/octet-stream",
-  })
+  let upload: Awaited<ReturnType<typeof notion.fileUploads.create>>
+  try {
+    upload = await notion.fileUploads.create({
+      mode: "single_part",
+      filename: file.name,
+      content_type: file.type || "application/octet-stream",
+    })
+  } catch (e) {
+    console.error("[uploadTaskAttachment] fileUploads.create failed:", e)
+    throw e
+  }
 
   // 2. ファイルデータを送信
-  await notion.fileUploads.send({
-    file_upload_id: upload.id,
-    file: { filename: file.name, data: file },
-  })
+  // Workers ランタイムでは受信 multipart 由来の File がストリーム読み取り済みになり得るため、
+  // arrayBuffer() で実体化した後に新しい Blob として渡す。
+  try {
+    const buf = await file.arrayBuffer()
+    const blob = new Blob([buf], { type: file.type || "application/octet-stream" })
+    await notion.fileUploads.send({
+      file_upload_id: upload.id,
+      file: { filename: file.name, data: blob },
+    })
+  } catch (e) {
+    console.error("[uploadTaskAttachment] fileUploads.send failed:", e)
+    throw e
+  }
 
   // 3. 既存ファイルを取得して配列末尾に新しい file_upload を追加
-  const existing = await fetchExistingFilesForUpdate(pageId)
+  let existing: Awaited<ReturnType<typeof fetchExistingFilesForUpdate>>
+  try {
+    existing = await fetchExistingFilesForUpdate(pageId)
+  } catch (e) {
+    console.error("[uploadTaskAttachment] fetchExistingFilesForUpdate failed:", e)
+    throw e
+  }
   const updated = [
     ...existing,
     { type: "file_upload" as const, file_upload: { id: upload.id }, name: file.name },
   ]
 
   // 4. ページを更新
-  const page = await notion.pages.update({
-    page_id: pageId,
-    properties: {
-      [NOTION_PROPS.FILES]: { files: updated },
-    } as Parameters<typeof notion.pages.update>[0]["properties"],
-  })
+  let page: Awaited<ReturnType<typeof notion.pages.update>>
+  try {
+    page = await notion.pages.update({
+      page_id: pageId,
+      properties: {
+        [NOTION_PROPS.FILES]: { files: updated },
+      } as Parameters<typeof notion.pages.update>[0]["properties"],
+    })
+  } catch (e) {
+    console.error("[uploadTaskAttachment] pages.update failed:", e)
+    throw e
+  }
 
   return extractAttachments(
     (page as PageObjectResponse).properties,


### PR DESCRIPTION
## Summary

- Cloudflare Workers ランタイムで `fileUploads.send` に渡す `File` を、`arrayBuffer()` で実体化した `Blob` 経由に変更（Workers の multipart パース済み `File` をそのまま渡すとボディが空になる問題の修正）
- アップロード各ステップ（create / send / fetchExisting / pages.update）に `console.error` ログを追加し、`wrangler tail` でどのステップで失敗したか確認できるよう整備
- `actions.ts` で `isNotionClientError` によりエラーを識別し、Notion のエラーメッセージをクライアントに渡せるよう修正（本番でも汎用エラー文字列でなく実際のエラー内容が表示される）

## Test plan

- [x] `npm run test:unit` — 15 ファイル・289 テスト全パス
- [ ] 本番でファイルアップロードが成功することを確認
- [ ] 2 個目のアップロード・削除も成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)