### PR TITLE
feat: 「対応不要」ステータスを追加

### DIFF
--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -28,14 +28,14 @@ test.describe("ボード", () => {
       }
     })
 
-    test("ボードに 6 カラムが描画される (進行中/未着手 はマージ、バックログは左端)", async () => {
+    test("ボードに 7 カラムが描画される (進行中/未着手 はマージ、バックログは左端)", async () => {
       // 各 status 名が必ずいずれかのカラムに含まれる (進行中/未着手 は同一カラム)
-      const expected = ["バックログ", "未着手", "進行中", "確認中", "一時中断", "完了", "中止"]
+      const expected = ["バックログ", "未着手", "進行中", "確認中", "一時中断", "完了", "中止", "対応不要"]
       for (const status of expected) {
         await expect(page.locator(COLUMN(status)).first()).toBeVisible()
       }
       const count = await page.locator("[data-testid='board-column']").count()
-      expect(count).toBe(6)
+      expect(count).toBe(7)
     })
 
     test("少なくとも1つのタスクが描画される", async () => {

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -75,6 +75,11 @@ export async function getBacklogTasksAction(): Promise<Task[]> {
   return getTasks({ statuses: ["バックログ"] })
 }
 
+export async function getSkipTasksAction(): Promise<Task[]> {
+  await requireAuth()
+  return getTasks({ statuses: ["対応不要"] })
+}
+
 export async function getTasksByIdsAction(ids: string[]): Promise<Task[]> {
   await requireAuth()
   if (ids.length === 0) return []

--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -7,22 +7,23 @@ import { applyAdvancedFilter } from "@/constants/filters"
 import { applySort } from "@/lib/task-sort"
 import { buildNestedOrder, filterCollapsed } from "@/lib/task-tree"
 import { STATUS_ACCENT } from "@/constants/styles"
-import { getCompletedTasksAction, getCancelledTasksAction, getBacklogTasksAction } from "@/app/actions"
+import { getCompletedTasksAction, getCancelledTasksAction, getBacklogTasksAction, getSkipTasksAction } from "@/app/actions"
 import { CyberLoader } from "./CyberLoader"
 
 // 列が viewport に入ってから fetch する重い (or 低頻度な) ステータス。
 // 完了/中止 は件数が多く、バックログ は「退避してたまに見る」想定なので初回ロードから外す。
-const LAZY_STATUSES: ReadonlySet<TaskStatus> = new Set(["完了", "中止", "バックログ"])
+const LAZY_STATUSES: ReadonlySet<TaskStatus> = new Set(["完了", "中止", "対応不要", "バックログ"])
 
 // 注: action 参照は遅延 (関数呼び出し時) に解決する。module-load 時に LAZY_STATUSES の
 // バリュー側で dereference すると、テストの vi.mock("@/app/actions", ...) が
 // すべての action を列挙していない場合に import が失敗する。
 function getLazyFetcher(status: TaskStatus): (() => Promise<Task[]>) | null {
   switch (status) {
-    case "完了":     return getCompletedTasksAction
-    case "中止":     return getCancelledTasksAction
+    case "完了":       return getCompletedTasksAction
+    case "中止":       return getCancelledTasksAction
+    case "対応不要":   return getSkipTasksAction
     case "バックログ": return getBacklogTasksAction
-    default:         return null
+    default:           return null
   }
 }
 

--- a/src/components/TaskBoard.tsx
+++ b/src/components/TaskBoard.tsx
@@ -23,6 +23,7 @@ const COLUMNS: ColumnSpec[] = [
   { key: "pause",   statuses: ["一時中断"],           title: "一時中断",           accentStatus: "一時中断" },
   { key: "done",    statuses: ["完了"],               title: "完了",               accentStatus: "完了" },
   { key: "cancel",  statuses: ["中止"],               title: "中止",               accentStatus: "中止" },
+  { key: "skip",    statuses: ["対応不要"],           title: "対応不要",           accentStatus: "対応不要" },
 ]
 const INITIAL_FOCUS_COLUMN_KEY = "wip"
 

--- a/src/components/__tests__/TaskItem.test.tsx
+++ b/src/components/__tests__/TaskItem.test.tsx
@@ -139,7 +139,7 @@ describe("TaskItem レンダリング", () => {
 
 describe("TaskItem STATUS_STYLES 網羅性", () => {
   // 各ステータスに対してバッジが表示されることを確認（スタイル抽出後の回帰防止）
-  const statuses = ["未着手", "進行中", "確認中", "一時中断", "完了", "中止", "アーカイブ済み"] as const
+  const statuses = ["未着手", "進行中", "確認中", "一時中断", "完了", "中止", "対応不要", "アーカイブ済み"] as const
 
   for (const status of statuses) {
     it(`"${status}" でクラッシュしない`, () => {

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -78,14 +78,14 @@ function getColumn(status: string) {
 }
 
 describe("TaskManager ボード", () => {
-  it("ボードに 6 カラム描画される (進行中/未着手は1カラムにマージ、バックログは左端)", () => {
+  it("ボードに 7 カラム描画される (進行中/未着手は1カラムにマージ、バックログは左端)", () => {
     render(
       <TaskManager tagOptions={[]} initialAdvancedFilter={NONE} initialSort={DEFAULT_SORT} tasks={tasks} />
     )
     const cols = document.querySelectorAll("[data-testid='board-column']")
-    expect(cols.length).toBe(6)
+    expect(cols.length).toBe(7)
     // 各 status が必ずいずれかのカラムに含まれる
-    for (const status of ["バックログ", "未着手", "進行中", "確認中", "一時中断", "完了", "中止"]) {
+    for (const status of ["バックログ", "未着手", "進行中", "確認中", "一時中断", "完了", "中止", "対応不要"]) {
       expect(getColumn(status)).toBeInTheDocument()
     }
   })

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -1,7 +1,7 @@
 import type { TaskPriority, TaskStatus } from "@/types/task"
 
 export const STATUS_OPTIONS: TaskStatus[] = [
-  "バックログ", "未着手", "進行中", "確認中", "一時中断", "完了", "中止",
+  "バックログ", "未着手", "進行中", "確認中", "一時中断", "完了", "中止", "対応不要",
 ]
 
 // セマンティック・ステータス: 「進行中」のみ accent + グローでサイバー DNA を残す。
@@ -14,6 +14,7 @@ export const STATUS_STYLES: Record<TaskStatus, string> = {
   "一時中断":     "font-pixel bg-transparent text-[var(--status-pause)] border border-[rgba(251,113,133,0.45)]",
   "完了":         "font-pixel bg-transparent text-[var(--status-done)] border border-[rgba(52,211,153,0.45)]",
   "中止":         "font-pixel bg-transparent text-[var(--status-cancel)] border border-[rgba(244,63,94,0.45)]",
+  "対応不要":     "font-pixel bg-transparent text-[var(--text-faint)] border border-[var(--border)]",
   "アーカイブ済み": "font-pixel bg-transparent text-[var(--text-faint)] border border-[var(--border)]",
 }
 
@@ -27,6 +28,7 @@ export const STATUS_ACCENT: Record<TaskStatus, string> = {
   "一時中断":       "var(--status-pause)",
   "完了":           "var(--status-done)",
   "中止":           "var(--status-cancel)",
+  "対応不要":       "var(--text-faint)",
   "アーカイブ済み": "var(--text-faint)",
 }
 

--- a/src/lib/task-sort.ts
+++ b/src/lib/task-sort.ts
@@ -3,7 +3,7 @@ import type { SortConfig, SortDirection, SortKey, Task, TaskStatus } from "@/typ
 const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 } as const
 
 export const STATUS_ORDER: TaskStatus[] = [
-  "バックログ", "未着手", "進行中", "確認中", "一時中断", "完了", "中止", "アーカイブ済み",
+  "バックログ", "未着手", "進行中", "確認中", "一時中断", "完了", "中止", "対応不要", "アーカイブ済み",
 ]
 
 export const DEFAULT_SORT: SortConfig = { key: "default", direction: "asc" }

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -6,6 +6,7 @@ export type TaskStatus =
   | "一時中断"
   | "完了"
   | "中止"
+  | "対応不要"
   | "アーカイブ済み"
 
 export type TaskPriority = "high" | "medium" | "low"


### PR DESCRIPTION
## Summary

- `TaskStatus` union に `"対応不要"` を追加（終端ステータス）
- 完了・中止と同じ遅延ロード方式の独立カンバンカラムを追加
- アクセント色はグレー系（`--text-faint`）で既存 CSS 変数を流用
- 作成フォームには出さない（後からドロップダウンで変更）
- `getSkipTasksAction` を新設し `BoardColumn` の遅延フェッチに接続

## Test plan

- [x] ユニットテスト 290件 全通過（`npm run test:unit`）
- [ ] Playwright E2E: 7カラム描画・ステータス変更フロー
- [ ] Notion DB の Status プロパティに「対応不要」オプションを手動追加してから動作確認

> ⚠️ **前提**: Notion DB 側の Status プロパティへ「対応不要」オプションの追加が別途必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)